### PR TITLE
implement Filter with method for setting language property of articles

### DIFF
--- a/internal_displacement/article.py
+++ b/internal_displacement/article.py
@@ -20,6 +20,7 @@ class Article(object):
         domain:                 the domain
         content_type:           the type of content (text,image,video etc)
         url:                    the url of the article
+        language:               the two-letter language code of the article
 
     """
 
@@ -31,6 +32,7 @@ class Article(object):
         self.domain = domain
         self.content_type = content_type
         self.url = url
+        self.language = ''
 
     def tag(self, tag):
         """Use interpreter to tag article

--- a/internal_displacement/filter.py
+++ b/internal_displacement/filter.py
@@ -1,0 +1,21 @@
+from langdetect import detect
+
+class Filter(object):
+    '''Filter that accepts an article and identifies the 
+    language and relevance of the article
+    '''
+
+    def __init__:
+        pass
+
+    def check_language(self, article):
+        '''Identify the language of the article content
+        '''
+        language = detect(article.content)
+        article.language = language
+
+    def check_relevance(self, article):
+        '''Tag the article as relevant or not based
+        upon its content.
+        '''
+        pass


### PR DESCRIPTION
Resolves #31.

I have implemented a Filter class (not sure if necessary as class but can change later), where we can perform various filtering or additional tagging actions when needed.

The method for identifying the language updates a new article property called language which could then be used elsewhere for filtering articles in other parts of the pipeline. I also thought this might give more flexibility in the future for incorporating additional languages etc.

If we agree on this approach, then in a separate issue will need to update article saving / updating methods for saving instances to disk.