### PR TITLE
Support for RDS Postgres

### DIFF
--- a/internal_displacement/database/schema.sql
+++ b/internal_displacement/database/schema.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS Labels;
+DROP TABLE IF EXISTS Articles;
+
+CREATE TABLE Articles (
+    url TEXT PRIMARY KEY,
+    title TEXT,
+    author TEXT,
+    publish_date TIMESTAMP,
+    domain TEXT,
+    content TEXT,
+    content_type TEXT,
+    language TEXT
+);
+
+
+CREATE TABLE Labels (
+    url TEXT REFERENCES Articles,
+    category TEXT
+)

--- a/internal_displacement/tests/test_SQLArticleInterface.py
+++ b/internal_displacement/tests/test_SQLArticleInterface.py
@@ -1,40 +1,55 @@
 from unittest import TestCase
+
+import dateutil
+
 from internal_displacement.pipeline import SQLArticleInterface
-from internal_displacement.article import Article
+from internal_displacement.article import Article, date_time_converter
 import os
 import datetime
 import pandas as pd
 class TestSQLArticleInterface(TestCase):
 
     def setUp(self):
-        self.pipeline = SQLArticleInterface("testing_db.sqlite")
+        pw = os.environ.get('TESTER_PASSWORD')
+        if pw:
+            self._POSTGRES = True
+            db_url = f"postgresql://tester:{pw}@internal-displacement.cf1y5y4ffeey.us-west-2.rds.amazonaws.com/id_test"
+            self.pipeline = SQLArticleInterface(db_url)
+            schema = os.path.abspath(os.path.join(__file__, '..', '..', 'database', 'schema.sql'))
+            self.pipeline.db.query_file(schema)
+        else:
+            self._POSTGRES = False
+            self.pipeline = SQLArticleInterface("sqlite:///testing_db.sqlite")
+
         self.date = datetime.datetime.now()
 
     def tearDown(self):
-        os.remove("testing_db.sqlite")
-
+        if self._POSTGRES:
+            self.pipeline.db.close()
+        else:
+            os.remove("testing_db.sqlite")
 
 
     def test_insert_article(self):
         test_article = Article("test_content",self.date,"test_title","test_content_type",["test_author_1","test_author_2"],"www.butts.com","www.butts.com/disasters")
         test_article_date_string = test_article.get_pub_date_string()
         self.pipeline.insert_article(test_article)
-        article_from_db = self.pipeline.sql_cursor.execute("SELECT * FROM Articles").fetchall()[0]
-        db_title = article_from_db[0]
+        article_from_db = self.pipeline.db.query("SELECT * FROM Articles")[0]
+        db_title = article_from_db.title
         self.assertEqual(db_title,"test_title")
-        db_url = article_from_db[1]
+        db_url = article_from_db.url
         self.assertEqual(db_url,"www.butts.com/disasters")
-        db_authors = article_from_db[2]
+        db_authors = article_from_db.author
         self.assertEqual(db_authors,"test_author_1,test_author_2")
-        db_publish_date = article_from_db[3]
+        db_publish_date = str(article_from_db.publish_date)
         self.assertEqual(db_publish_date,test_article_date_string)
-        db_domain = article_from_db[4]
+        db_domain = article_from_db.domain
         self.assertEqual(db_domain,"www.butts.com")
-        db_text = article_from_db[5]
+        db_text = article_from_db.content
         self.assertEqual(db_text,"test_content")
-        db_content_type = article_from_db[6]
+        db_content_type = article_from_db.content_type
         self.assertEqual(db_content_type,"test_content_type")
-        db_language = article_from_db[7]
+        db_language = article_from_db.language
         self.assertEqual(db_language,"EN")
 
 
@@ -46,7 +61,7 @@ class TestSQLArticleInterface(TestCase):
         updated_article.change_language("EN")
         self.assertEqual(updated_article.language,"EN")
         self.pipeline.update_article(updated_article)
-        db_article_language = self.pipeline.sql_cursor.execute("SELECT language FROM Articles").fetchone()[0]
+        db_article_language = self.pipeline.db.query("SELECT language FROM Articles")[0].language
         self.assertEqual(db_article_language,"EN")
 
     def test_to_csv(self):
@@ -56,14 +71,15 @@ class TestSQLArticleInterface(TestCase):
         self.pipeline.insert_article(test_article)
         self.pipeline.to_csv("Articles","testing_csv.csv")
         test_csv_df = pd.read_csv("testing_csv.csv")
-        columns = ["title" , "url" ,"author" ,"publish_date" ,"domain" ,
+        columns = ["url", "title" , "author" ,"publish_date" ,"domain" ,
                 "content" , "content_type" , "language"]
         self.assertEqual(list(test_csv_df.columns),columns)
         csv_first_row_values = list(test_csv_df.values[0])
-        expected_csv_row = ["test_content", test_article_date_string, "test_title", "test_content_type","test_author_1,test_author_2","www.butts.com","www.butts.com/disasters","EN"]
+        csv_first_row_values[3] = dateutil.parser.parse(csv_first_row_values[3])
+        expected_csv_row = ["test_content", self.date, "test_title", "test_content_type","test_author_1,test_author_2","www.butts.com","www.butts.com/disasters","EN"]
         self.assertCountEqual(csv_first_row_values,expected_csv_row) #FYI assertCountEqual actually asserts that lists contains the same values (independent of order) (poorly named method).
-        self.assertEqual(csv_first_row_values[0],"test_title")
-        self.assertEqual(csv_first_row_values[1],"www.butts.com/disasters")
+        self.assertEqual(csv_first_row_values[1],"test_title")
+        self.assertEqual(csv_first_row_values[0],"www.butts.com/disasters")
         self.assertEqual(csv_first_row_values[2],"test_author_1,test_author_2")
         self.assertNotEqual(csv_first_row_values[2], "Mr Bananarama") #Sanity check.
         os.remove("testing_csv.csv")

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ jupyter==1.0.0
 jupyter-client==4.4.0
 jupyter-console==5.1.0
 jupyter-core==4.2.1
+langdetect==1.0.7
 lxml==3.7.2
 MarkupSafe==0.23
 mistune==0.7.3
@@ -26,6 +27,7 @@ nbconvert==5.1.1
 nbformat==4.2.0
 newspaper3k==0.1.9
 nltk==3.2.2
+nose==1.3.7
 notebook==4.3.2
 numpy==1.12.0
 olefile==0.44
@@ -35,17 +37,21 @@ pexpect==4.2.1
 pickleshare==0.7.4
 Pillow==4.0.0
 prompt-toolkit==1.0.13
+psycopg2==2.6.2
 ptyprocess==0.5.1
+pycountry==17.1.8
 Pygments==2.2.0
 python-dateutil==2.6.0
 pytz==2016.10
 PyYAML==3.12
 pyzmq==16.0.2
 qtconsole==4.2.1
+records==0.5.0
 requests==2.13.0
 requests-file==1.4.1
 simplegeneric==0.8.1
 six==1.10.0
+spacy==1.6.0
 terminado==0.6
 testpath==0.3
 tldextract==2.0.2


### PR DESCRIPTION
- Using the records library (on top of SQLAlchemy) as a layer to support both sqlite and postgresql. - Added postgres schema to match sqlite schema.
- Updated unit tests to pass in both (need to set the TESTER_PASSWORD environment variable to test against postgresql)
- Updated requirements.txt with some packages I had to install to get this to be testable