### PR TITLE
Interpreter enhancements

### DIFF
--- a/internal_displacement/report.py
+++ b/internal_displacement/report.py
@@ -13,7 +13,10 @@ def convert_tokens_to_strings(value):
 
 class Report:
     def __init__(self, locations, date_times, event_term, subject_term, quantity, story):
-        self.locations = [convert_tokens_to_strings(l) for l in locations]
+        if locations:
+            self.locations = [convert_tokens_to_strings(l) for l in locations]
+        else:
+            self.locations = []
         if date_times:
             self.date_times = [convert_tokens_to_strings(dt) for dt in date_times]
         else:

--- a/internal_displacement/tests/test_fact_extraction.py
+++ b/internal_displacement/tests/test_fact_extraction.py
@@ -125,8 +125,8 @@ outcomes.append(test_outcome)
 
 article = 'As many as 2,214 households have been affected by the rainstorms in Rio Grande do Sul, the Emergency Management Service reported today (Dec. 28). A total of 1,964 households were displaced. The storms hit forty municipalities.  According to the government of Rio Grande do Sul, the State Coordination for Emergency Management continues to monitor and provide assistance to the impacted municipalities and communities.  Last Saturday (26), President Rousseff flew over the region, which borders Argentina and Uruguay, and announced the provision of $6.6 million to help communities hit by the floods.  This has been the fifth flood this year in the state, and the most severe. The Quaraí river rose a record 15.28 meters. The situation got even worse with the rise of the Uruguay river.  The rainstorm has disrupted rice harvest in the municipality of Quaraí and caused the Quaraí-Artigas international bridge between Brazil and Uruguay to remain closed off for 22 hours.    Translated by Mayra Borges'
 expected_reports = []
-expected_reports.append(Report(['Rio Grande do Sul'], ['Dec. 28'], 'displace', 'household', '1,964', ''))
-expected_reports.append(Report(['Rio Grande do Sul'], ['Dec. 28'], 'affect', 'household', '2,214', ''))
+expected_reports.append(Report(['Rio Grande do Sul'], ['today', 'Dec. 28'], 'displace', 'household', '1,964', ''))
+expected_reports.append(Report(['Rio Grande do Sul'], ['today', 'Dec. 28'], 'affect', 'household', '2,214', ''))
 test_outcome = test_fact_extraction(article, expected_reports)
 outcomes.append(test_outcome)
 

--- a/internal_displacement/tests/test_fact_extraction.py
+++ b/internal_displacement/tests/test_fact_extraction.py
@@ -118,8 +118,8 @@ outcomes.append(test_outcome)
 
 article = "BEIJING, March 31 (Xinhua) -- The Ministry of Civil Affairs has sent 1,000 tents, 2,000 sleeping bags, 2,000 folding beds and 1,000 sets of folding desks and chairs to Jianhe County in southwestern Guizhou Province after it was hit by a 5.5-magnitude earthquake on Monday morning.  No deaths have been reported, though the quake was Guizhou's biggest in terms of magnitude since 1949. More than 23,000 people have been affected and 2,536 relocated.  Provincial authorities have sent teams to help with the rescue work and allocated 1 million yuan (about 162,880 U.S. dollars) and 206 tents for disaster relief."
 expected_reports = []
-expected_reports.append(Report(['Guizhou'], ['Monday morning'], 'relocate', 'person', '2,536', ''))
-expected_reports.append(Report(['Guizhou'], ['Monday morning'], 'affect', 'people', '23,000', ''))
+expected_reports.append(Report(['Guizhou'], ['Monday'], 'relocate', 'person', '2,536', ''))
+expected_reports.append(Report(['Guizhou'], ['Monday'], 'affect', 'people', '23,000', ''))
 test_outcome = test_fact_extraction(article, expected_reports)
 outcomes.append(test_outcome)
 


### PR DESCRIPTION
I have implemented a `date_likelihood` for filtering out certain types of dates, for example a comparison to an event from many years ago, or a reference to a date in the future.

Currently this is applied prior to returning dates from the `extract_dates` function.

Let me know if you think there is a better or cleaner way to do this. Thanks