### PR TITLE
Interpreter enhancements

### DIFF
--- a/internal_displacement/interpreter.py
+++ b/internal_displacement/interpreter.py
@@ -127,8 +127,7 @@ class Interpreter():
         in the article, and return an array containing all
         mentioned countries
         '''
-        text = " ".join([article.title, article.content])
-        doc = self.nlp(u"{}".format(text))
+        doc = self.nlp(u"{}".format(article))
         possible_entities = set()
         for ent in doc.ents:
             if ent.label_ in ('GPE', 'LOC'):

--- a/internal_displacement/interpreter.py
+++ b/internal_displacement/interpreter.py
@@ -91,10 +91,10 @@ class Interpreter():
         and update the article property 'language'
         '''
         try:
-            language = textacy.text_utils.detect_language(article.content)
+            language = textacy.text_utils.detect_language(article)
         except ValueError:
             language = 'na'
-        article.language = language
+        return language
 
     def check_relevance(self, article):
         '''Tag the article as relevant or not based

--- a/internal_displacement/tests/test_Interpreter.py
+++ b/internal_displacement/tests/test_Interpreter.py
@@ -44,9 +44,8 @@ class TestInterpreter(TestCase):
         test_article = Article("A decent amount of test content which will be used for extracting the language",
                                self.date, "test_title", "test_content_type", [
                                    "test_author_1", "test_author_2"], "www.butts.com", "www.butts.com/disasters")
-        self.interpreter.check_language(test_article)
-        article_language = test_article.language
-        self.assertEqual(article_language, "en")
+        language = self.interpreter.check_language(test_article.content)
+        self.assertEqual(language, "en")
 
     def test_strip_words(self):
         test_place_name = 'the province county district city'


### PR DESCRIPTION
Change the `Interpreter.check_language` and `Interpreter.extract_countries` functions to work on strings rather than articles.
Article attributes should be updated separately from the pipeline.

Expand parse dependencies for reporting units directly following and preceding reporting terms.

Add a check for reporting terms that can apply to both Structures and People
