### PR TITLE
Docker compose web

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "internal-displacement-web"]
+	path = internal-displacement-web
+	url = git@github.com:Data4Democracy/internal-displacement-web.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "internal-displacement-web"]
-	path = internal-displacement-web
-	url = git@github.com:Data4Democracy/internal-displacement-web.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "internal-displacement-web"]
 	path = internal-displacement-web
 	url = git@github.com:Data4Democracy/internal-displacement-web.git
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
-RUN mkdir /project
-VOLUME /project
-WORKDIR /project
+RUN mkdir /internal-displacement
+VOLUME /internal-displacement
+WORKDIR /internal-displacement
 
 RUN apt-get update
 RUN apt-get -y install python3 python3-pip python3-dev libxml2-dev \
@@ -14,8 +14,8 @@ RUN pip3 install --upgrade pip && \
     pip3 install git+git://github.com/aerkalov/ebooklib.git && \
     pip3 install textract
 
-COPY . /project
+COPY . /internal-displacement
 
-RUN pip3 install -r /project/requirements.txt
+RUN pip3 install -r /internal-displacement/requirements.txt
 
 CMD jupyter notebook --no-browser --ip=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ be installed in a controlled, reproducible way.
 
 1. Install Docker: https://www.docker.com/products/overview
 
-2. Add the web interface as a submodule...
+2. Pull in the web interface as a submodule...
    ```
-   git submodule add git@github.com:Data4Democracy/internal-displacement-web.git
+   git submodule update --init --recursive .
 
    ```
 

--- a/README.md
+++ b/README.md
@@ -85,31 +85,49 @@ another option is to run in a Docker container. That way, all of the dependencie
 be installed in a controlled, reproducible way.
 
 1. Install Docker: https://www.docker.com/products/overview
-2. Build the docker container (unfortunately, this will take a while the first time):
+
+2. Run this command:
+
+   ```
+   docker-compose up
+   ```
+
+   Unfortunately, this will take quite a while the first time. It's fetching and building
+   all of its dependencies. Subsequent runs should be much faster.
+
+   This will start up a couple of docker containers, one running postgres, and the other
+   running a Jupyter notebook server.
+
+   In the output, you should see a line like:
+   ```
+   jupyter_1  |         http://0.0.0.0:8888/?token=536690ac0b189168b95031769a989f689838d0df1008182c
+   ```
+
+   That URL will connect you to the Jupyter notebook server.
+
+3. Set up the database schema by running the contents of the
+[InitDB.ipynb](http://0.0.0.0:8888/notebooks/InitDB.ipynb) notebook.
+
+
+Note: You can stop the docker containers using Ctrl-C.
+
+Note: If you already have something running on port 8888, edit `docker-compose.yml` and change the *first* 8888
+in the ports config to a free port on your system. eg. for 9999, make it:
+```
+    ports:
+      - "9999:8888"
+```
+
+Note: If you want to add python dependencies, add them to `requirements.txt` and run `docker-compose up --build`.
+
+Note: if you want to run SQL commands againt the database directly, you can do
+that by starting a Terminal within Jupyter and running the PostgreSQL shell:
+```
+psql -h localdb -U tester id_test
 
 ```
-docker build -t internal-displacement .
-```
-You'll need to do this again if you want to install python dependencies by adding them to `requirements.txt`,
-but it should be faster on subsequent runs.
 
-3. Run the container. By default, this starts a jupyter notebook server (change the first 8888 to another port, if you're already running something there):
-
-```
-docker run -it --rm --env-file docker.env -p 8888:8888 -v $PWD:/project internal-displacement
-```
- - `-it` set up the terminal to run interactively
- - `--rm` remove the container when it's finished
- - `--env-file docker.env` set up environment variables from this file (notably, tells it where the DB is)
- - `-p 8888:8888` map http://localhost:8888 to the jupyter server running on port 8888 inside the docker container
- - `-v $PWD:/project` map the current directory into the docker container so that changes you make inside the container
- also appear out here
-    
-4. You can also run the unit tests with:
-
-```
-docker run --rm --env-file docker.env -v $PWD:/project internal-displacement nosetests
-```
+Note: If you want to connect to a remote database, edit the `docker.env` file with the DB url for your remote database.
 
 
 ### Progress

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ be installed in a controlled, reproducible way.
 
 1. Install Docker: https://www.docker.com/products/overview
 
+2. Add the web interface as a submodule...
+   ```
+   git submodule add git@github.com:Data4Democracy/internal-displacement-web.git
+
+   ```
+
 2. Run this command:
 
    ```
@@ -109,10 +115,12 @@ be installed in a controlled, reproducible way.
 [InitDB.ipynb](http://0.0.0.0:8888/notebooks/InitDB.ipynb) notebook.
 
 
+4. Visit the node.js server at [http://localhost:3000](http://localhost:3000)
+
 Note: You can stop the docker containers using Ctrl-C.
 
-Note: If you already have something running on port 8888, edit `docker-compose.yml` and change the *first* 8888
-in the ports config to a free port on your system. eg. for 9999, make it:
+Note: If you already have something running on port 8888 or 3000, edit `docker-compose.yml` and change the first
+number in the ports config to a free port on your system. eg. for 9999, make it:
 ```
     ports:
       - "9999:8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     build: internal-displacement-web
     image: internal-displacement-web
     volumes:
-      - ./internal-displacement-web:/internal-displacement-web
+      - ./internal-displacement-web/src:/internal-displacement-web/src
+      - ./internal-displacement-web/package.json:/internal-displacement-web/package.json
+      - ./internal-displacement-web/index.html:/internal-displacement-web/index.html
     ports:
       - "3000:80"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  localdb:
+    build: localdb
+    image: localdb
+  jupyter:
+    build: .
+    image: internal_displacement
+    command: sh -c "jupyter notebook --no-browser --ip=0.0.0.0 /project/notebooks"
+    env_file: docker.env
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/project
+    ports:
+      - "8888:8888"
+    depends_on:
+      - localdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,24 @@ services:
     image: localdb
   jupyter:
     build: .
-    image: internal_displacement
-    command: sh -c "jupyter notebook --no-browser --ip=0.0.0.0 /project/notebooks"
+    image: internal-displacement
+    command: sh -c "jupyter notebook --no-browser --ip=0.0.0.0 /internal-displacement/notebooks"
     env_file: docker.env
     stdin_open: true
     tty: true
     volumes:
-      - .:/project
+      - .:/internal-displacement
     ports:
       - "8888:8888"
     depends_on:
       - localdb
+  nodejs:
+    build: ../internal-displacement-web
+    image: internal-displacement-web
+    volumes:
+      - ../internal-displacement-web:/internal-displacement-web
+    ports:
+      - "3000:80"
+    depends_on:
+      - localdb
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,11 @@ services:
     depends_on:
       - localdb
   nodejs:
-    build: ../internal-displacement-web
+    build: internal-displacement-web
     image: internal-displacement-web
     volumes:
-      - ../internal-displacement-web:/internal-displacement-web
+      - ./internal-displacement-web:/internal-displacement-web
     ports:
       - "3000:80"
     depends_on:
       - localdb
-

--- a/docker.env
+++ b/docker.env
@@ -3,4 +3,4 @@
 DB_HOST=localdb
 DB_USER=tester
 DB_PASS=tester
-PYTHONPATH=/project
+PYTHONPATH=/internal-displacement

--- a/docker.env
+++ b/docker.env
@@ -1,2 +1,2 @@
 # Ask @aneel on the Slack for actual DB credentials. Please do not commit them to git.
-DB_URL=postgresql://user:password@internal-displacement.cf1y5y4ffeey.us-west-2.rds.amazonaws.com/id_test
+DB_URL=postgresql://tester:tester@localdb/id_test

--- a/docker.env
+++ b/docker.env
@@ -1,3 +1,6 @@
-# Ask @aneel on the Slack for actual DB credentials. Please do not commit them to git.
-DB_URL=postgresql://tester:tester@localdb/id_test
-PYTHONPATH=/internal-displacement
+# Localdb is a database running on your machine in Docker. If you need access to the
+# shared DB, please ask @aneel on the Slack for credentials. Please do not commit them to git.
+DB_HOST=localdb
+DB_USER=tester
+DB_PASS=tester
+PYTHONPATH=/project

--- a/docker.env
+++ b/docker.env
@@ -1,2 +1,3 @@
 # Ask @aneel on the Slack for actual DB credentials. Please do not commit them to git.
 DB_URL=postgresql://tester:tester@localdb/id_test
+PYTHONPATH=/internal-displacement

--- a/internal_displacement/model/model.py
+++ b/internal_displacement/model/model.py
@@ -1,4 +1,7 @@
-from sqlalchemy import Table
+import os
+
+from sqlalchemy import Table, text
+from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean, Numeric
 from sqlalchemy.orm import sessionmaker, relationship
@@ -121,3 +124,19 @@ class ReportDateSpan(Base):
     report = relationship('Report', back_populates='datespans')
     start = Column(DateTime)
     finish = Column(DateTime)
+
+
+def init_db(db_url, i_know_this_will_delete_everything=False):
+    """
+    Warning! This will delete everything in the database!
+    :param session: SQLAlchemy session
+    """
+    if not i_know_this_will_delete_everything:
+        raise RuntimeError("Tried to init_db without knowing it would delete everything!")
+    engine = create_engine(db_url)
+    Session.configure(bind=engine)
+    session = Session()
+    sql_path = os.path.join(os.path.dirname(__file__), 'schema.sql')
+    with open(sql_path, 'r') as schema:
+        session.execute(text(schema.read()))
+    session.commit()

--- a/internal_displacement/tests/test_model.py
+++ b/internal_displacement/tests/test_model.py
@@ -3,17 +3,17 @@ from datetime import datetime
 from unittest import TestCase
 
 from sqlalchemy import create_engine
+
 from internal_displacement.model.model import Status, Session, Category, Article, Content, Country, CountryTerm, \
     Location, Report, ReportDateSpan, ArticleCategory
 
 
 class TestModel(TestCase):
-
     def setUp(self):
-        DB_URL = os.environ.get('DB_URL')
-        if not DB_URL.endswith('/id_test'):
-            raise RuntimeError('Refusing to run tests against non-test database')
-        engine = create_engine(DB_URL)
+        db_host = os.environ.get('DB_HOST')
+        db_url = 'postgresql://{user}:{passwd}@{db_host}/{db}'.format(
+            user='tester', passwd='tester', db_host=db_host, db='id_test')
+        engine = create_engine(db_url)
         Session.configure(bind=engine)
         self.session = Session()
 

--- a/internal_displacement/tests/test_model.py
+++ b/internal_displacement/tests/test_model.py
@@ -33,12 +33,12 @@ class TestModel(TestCase):
         ArticleCategory(article=article, category=Category.OTHER)
         self.session.add(article)
 
-        article2 = self.session.query(Article).filter_by(status = Status.NEW).one()
+        article2 = self.session.query(Article).filter_by(status=Status.NEW).one()
         self.assertEqual(article2.domain, 'example.com')
         self.assertEqual(article2.content.content, "La la la")
         self.assertCountEqual([c.category for c in article2.categories], ['disaster', 'other'])
 
-        article3 = self.session.query(Article).filter_by(status = Status.NEW).one()
+        article3 = self.session.query(Article).filter_by(status=Status.NEW).one()
         self.assertEqual(article3.domain, 'example.com')
 
     def test_delete_article(self):
@@ -61,15 +61,14 @@ class TestModel(TestCase):
                 self.session.delete(article)
             self.session.commit()
 
-
     def test_country_term(self):
         mmr = self.session.query(Country).filter_by(code="MMR").one_or_none() or Country(code="MMR")
         myanmar = CountryTerm(term="Myanmar", country=mmr)
         burma = CountryTerm(term="Burma", country=mmr)
         self.session.add(mmr)
 
-        myanmar = self.session.query(Country).join(CountryTerm).filter_by(term = 'Myanmar').one()
-        burma = self.session.query(Country).join(CountryTerm).filter_by(term = 'Burma').one()
+        myanmar = self.session.query(Country).join(CountryTerm).filter_by(term='Myanmar').one()
+        burma = self.session.query(Country).join(CountryTerm).filter_by(term='Burma').one()
         self.assertEqual(myanmar, burma)
 
     def test_location(self):
@@ -94,7 +93,6 @@ class TestModel(TestCase):
                             quantity='72')
             self.session.add(report)
             self.session.commit()  # have to commit here to get the ID set
-            print(report.id)
 
             naypyidaw = Location(description="Nay Pyi Taw", country=mmr, latlong='19°45′N 96°6′E')
             report.locations.append(naypyidaw)
@@ -103,7 +101,7 @@ class TestModel(TestCase):
             now = datetime.now()
             when = ReportDateSpan(report=report, start=datetime.today(), finish=now)
 
-            article2 = self.session.query(Article).filter_by(domain = 'example.com').first()
+            article2 = self.session.query(Article).filter_by(domain='example.com').first()
             self.assertEqual(len(article2.reports), 1)
 
             article3 = self.session.query(Article).join(Report).filter(Report.locations.contains(dhaka)).first()
@@ -115,7 +113,6 @@ class TestModel(TestCase):
             if article:
                 self.session.delete(article)
             self.session.commit()
-
 
     def test_report_delete(self):
         article = None

--- a/localdb/Dockerfile
+++ b/localdb/Dockerfile
@@ -1,3 +1,3 @@
 FROM postgres
 
-COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d
+COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/

--- a/localdb/Dockerfile
+++ b/localdb/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres
+
+COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d

--- a/localdb/docker-entrypoint-initdb.d/id.sh
+++ b/localdb/docker-entrypoint-initdb.d/id.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE USER jupyter WITH PASSWORD 'jupyter';
+    CREATE USER nodejs WITH PASSWORD 'nodejs';
+    CREATE DATABASE id;
+    GRANT ALL PRIVILEGES ON DATABASE id TO jupyter;
+    GRANT ALL PRIVILEGES ON DATABASE id TO nodejs;
+EOSQL

--- a/localdb/docker-entrypoint-initdb.d/id_test.sh
+++ b/localdb/docker-entrypoint-initdb.d/id_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE USER tester WITH PASSWORD 'tester';
+    CREATE DATABASE id_test;
+    GRANT ALL PRIVILEGES ON DATABASE id_test TO tester;
+EOSQL

--- a/notebooks/InitDB.ipynb
+++ b/notebooks/InitDB.ipynb
@@ -10,16 +10,25 @@
    },
    "outputs": [],
    "source": [
-    "# Change this to True to set up the DB the first time\n",
+    "# Change these to True to set up the DB the first time\n",
     "i_know_this_will_delete_everything = False\n",
+    "initialize_id_test = False\n",
+    "initialize_id = False\n",
     "\n",
     "import os\n",
     "from internal_displacement.model.model import init_db\n",
     "\n",
-    "db_url = os.environ.get('DB_URL')\n",
-    "if not db_url.endswith('/id_test'):\n",
-    "    raise RuntimeError('Refusing to run tests against non-test database')\n",
-    "init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)"
+    "db_host = os.environ.get('DB_HOST')\n",
+    "\n",
+    "if initialize_id:\n",
+    "    db_url = 'postgresql://{user}:{pass}@{db_host}/{db}'.format(\n",
+    "        user='jupyter', pass='jupyter', db_host=db_host, db='id')\n",
+    "    init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)\n",
+    "    \n",
+    "if initialize_id_test:\n",
+    "    db_url = 'postgresql://{user}:{pass}@{db_host}/{db}'.format(\n",
+    "        user='tester', pass='tester', db_host=db_host, db='id_test')\n",
+    "    init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)"
    ]
   },
   {
@@ -47,7 +56,9 @@
     "editable": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -59,7 +70,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/notebooks/InitDB.ipynb
+++ b/notebooks/InitDB.ipynb
@@ -21,13 +21,13 @@
     "db_host = os.environ.get('DB_HOST')\n",
     "\n",
     "if initialize_id:\n",
-    "    db_url = 'postgresql://{user}:{pass}@{db_host}/{db}'.format(\n",
-    "        user='jupyter', pass='jupyter', db_host=db_host, db='id')\n",
+    "    db_url = 'postgresql://{user}:{password}@{db_host}/{db}'.format(\n",
+    "        user='jupyter', password='jupyter', db_host=db_host, db='id')\n",
     "    init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)\n",
     "    \n",
     "if initialize_id_test:\n",
-    "    db_url = 'postgresql://{user}:{pass}@{db_host}/{db}'.format(\n",
-    "        user='tester', pass='tester', db_host=db_host, db='id_test')\n",
+    "    db_url = 'postgresql://{user}:{password}@{db_host}/{db}'.format(\n",
+    "        user='tester', password='tester', db_host=db_host, db='id_test')\n",
     "    init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)"
    ]
   },
@@ -56,9 +56,7 @@
     "editable": true
    },
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -70,7 +68,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/notebooks/InitDB.ipynb
+++ b/notebooks/InitDB.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Change this to True to set up the DB the first time\n",
+    "i_know_this_will_delete_everything = False\n",
+    "\n",
+    "import os\n",
+    "from internal_displacement.model.model import init_db\n",
+    "\n",
+    "db_url = os.environ.get('DB_URL')\n",
+    "if not db_url.endswith('/id_test'):\n",
+    "    raise RuntimeError('Refusing to run tests against non-test database')\n",
+    "init_db(db_url, i_know_this_will_delete_everything=i_know_this_will_delete_everything)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import unittest\n",
+    "from internal_displacement.tests.test_model import TestModel\n",
+    "suite = unittest.TestLoader().loadTestsFromTestCase(TestModel)\n",
+    "unittest.TextTestRunner(verbosity=3).run(suite)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This commit makes `docker-compose up` run both the internal-displacement (jupyter) and internal-displacement-web (node.js) containers. See the readme about git submodules.

This should give both the python code and the node code access to the same local database.