### PR TITLE
process location city and subdivision

### DIFF
--- a/internal_displacement/interpreter.py
+++ b/internal_displacement/interpreter.py
@@ -62,7 +62,7 @@ def common_names(place_name):
     }.get(place_name, place_name)
 
 
-def province_country_code(place_name):
+def subdivision_country_code(place_name):
     '''Try and extract the country code by looking
     at country subdivisions i.e. States, Provinces etc.
     return the country code if found
@@ -203,23 +203,25 @@ class Interpreter():
             return Category.OTHER
 
 
-    def country_code(self, place_name):
-        '''Find the ISO-3166 alpha_2 country code
-        for a given country name
+    def city_subdivision_country(self, place_name):
+        '''Return dict with city (if applicable), subdivision (if applicable),
+        and the ISO-3166 alpha_3 country code for a given place name.
+        Return None if the country cannot be identified.
         '''
         place_name = common_names(place_name)
         country_code_from_name = match_country_name(place_name)
         if country_code_from_name:
-            return country_code_from_name
-        # Try getting the country code using a province name
-        country_from_province = province_country_code(place_name)
-        if country_from_province:
-            return country_from_province
+            return {'city': None, 'subdivision': None, 'country': country_code_from_name}
+        # Try getting the country code using a subdivision name
+        country_from_subdivision = subdivision_country_code(place_name)
+        if country_from_subdivision:
+            return {'city': None, 'subdivision': place_name, 'country': country_from_subdivision}
         # Try getting the country code using a city name
         country_code = self.cities_to_countries.get(
             strip_accents(place_name), None)
         if country_code:
-            return pycountry.countries.get(alpha_2=country_code).alpha_3
+            return {'city': place_name, 'subdivision': None,
+                    'country': pycountry.countries.get(alpha_2=country_code).alpha_3}
         return None
 
     def extract_countries(self, article):

--- a/internal_displacement/model/model.py
+++ b/internal_displacement/model/model.py
@@ -119,6 +119,8 @@ class Location(Base):
 
     id = Column(Integer, primary_key=True)
     description = Column(String)
+    city = Column(String)
+    subdivision = Column(String)
     code = Column('country', String(3), ForeignKey('country.code'))
     country = relationship('Country', back_populates='locations')
     latlong = Column(String)  # Not tackling PostGIS right now

--- a/internal_displacement/model/schema.sql
+++ b/internal_displacement/model/schema.sql
@@ -49,6 +49,8 @@ DROP TABLE IF EXISTS location CASCADE;
 CREATE TABLE location (
     id SERIAL PRIMARY KEY,
     description TEXT,
+    city TEXT,
+    subdivision TEXT,
     country CHAR(3) REFERENCES country ON DELETE CASCADE,
     latlong TEXT
 );

--- a/internal_displacement/pipeline.py
+++ b/internal_displacement/pipeline.py
@@ -254,11 +254,14 @@ class Pipeline(object):
         if loc:
             report.locations.append(loc)
         else:
-            country_code = self.interpreter.country_code(location)
-            if country_code:
+            loc_dict = self.interpreter.city_subdivision_country(location)
+            if loc_dict:
                 country = self.session.query(Country).filter_by(
-                    code=country_code).one_or_none()
-                location = Location(description=location, country=country)
+                    code=loc_dict['country']).one_or_none()
+                location = Location(description=location,
+                                    city=loc_dict['city'],
+                                    subdivision=loc_dict['subdivision'],
+                                    country=country)
                 self.session.add(location)
                 self.session.commit()
                 report.locations.append(location)


### PR DESCRIPTION
Addresses issue #112. SQL Location table now stores city and subdivision as well
as country. When adding a location to the table, pipeline.py/interpreter.py use
location name to find the country code as before, but now also save the location
name in the "city" or "subdivision" field as well, as appropriate.