### PR TITLE
Change the way dates are extracted and used for reports.

### DIFF
--- a/data/idmc_uniteideas_training_dataset.csv
+++ b/data/idmc_uniteideas_training_dataset.csv
@@ -1,0 +1,689 @@
+Country_or_region,URL,Tag
+Abyei Area,http://www.securitycouncilreport.org/atf/cf/%7B65BFCF9B-6D27-4E9C-8CD3-CF6E4FF96FF9%7D/S_2015_302.pdf,Conflict and violence
+Afghanistan,http://www.independent.co.uk/news/world/asia/160-killed-and-hundreds-left-stranded-by-flooding-across-afghanistan-and-pakistan-8746566.html,Disasters
+Afghanistan,http://reliefweb.int/sites/reliefweb.int/files/resources/Natural%20Hazards%20Update%204-10%20February_1.pdf,Disasters
+Afghanistan,https://www.humanitarianresponse.info/en/operations/afghanistan/document/rafdump01-jan-2015-till-31-dec-2015-0,Disasters
+Afghanistan,http://floodlist.com/asia/afghanistan-flash-floods-faryab-baghlan-8-dead,Disasters
+Afghanistan,http://floodlist.com/asia/afghanistan-6-dead-flash-floods-kofab-badakhshan-july-2015,Disasters
+Afghanistan,http://reliefweb.int/report/afghanistan/afghanistan-earthquake-overview-assessed-needs-and-response-23-november-2015,Disasters
+Afghanistan,http://reliefweb.int/sites/reliefweb.int/files/resources/25_dec_15_afg_earthquake_flash_update_-_no._3_-_3_jan_15_0.pdf,Disasters
+Afghanistan,http://erccportal.jrc.ec.europa.eu/getdailymap/docId/1125,Disasters
+Afghanistan,http://www.unhcr.af/UploadDocs/DocumentLibrary/UNHCR_IDP_Monthly_update_January_2015_635602076387647568.pdf,Conflict and violence
+Afghanistan,http://www.unhcr.af/UploadDocs/DocumentLibrary/IDP_monthly_update_February_2015_635633080076254870.pdf,Conflict and violence
+Afghanistan,http://www.refworld.org/pdfid/5534d99e4.pdf,Conflict and violence
+Afghanistan,http://www.unhcr.af/UploadDocs/DocumentLibrary/UNHCR_Monthly_IDP_update_April_2015_635680629279025367.pdf,Conflict and violence
+Afghanistan,http://www.unhcr.af/UploadDocs/DocumentLibrary/May_2015_IDP_Report_635713402501810000.pdf,Conflict and violence
+Afghanistan,http://www.unhcr.af/UploadDocs/DocumentLibrary/UNHCR_IDP_monthly_update_July_2015n__635773959559320000.pdf,Conflict and violence
+Albania,http://www.euronews.com/2014/11/19/albania-floods-kill-at-least-3-people/,Disasters
+Algeria,http://www.aps.dz/regions/10028-pr%C3%A8s-de-1-100-familles-victimes-du-s%C3%A9isme-du-1er-ao%C3%BBt-relog%C3%A9es-%C3%A0-alger,Disasters
+Algeria,http://floodlist.com/africa/torrential-rains-destroy-400-homes-in-algeria,Disasters
+Angola,"http://www.portalangop.co.ao/angola/pt_pt/noticias/sociedade/2013/2/12/Chuva-deixa-ruas-bairros-Luanda-inundados,b27f0ede-c278-48e7-9648-67e6d8236f03.html",Disasters
+Angola,http://floodlist.com/africa/thousands-homes-damaged-floods-luanda-angola,Disasters
+Angola,"http://www.portalangop.co.ao/angola/en_us/noticias/sociedade/2015/3/14/Cuanza-Sul-Over-thousand-affected-rains,a0585a11-a431-46f7-be3c-9d89c7a3cfbc.html",Disasters
+Argentina,http://www.argentinaindependent.com/tag/rio-parana/,Disasters
+Argentina,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-List/yy/2014/mm/6,Disasters
+Argentina,http://www.lanacion.com.ar/1679075-el-mapa-de-las-inundaciones-en-todo-el-pais-cuales-son-las-zonas-afectadas,Disasters
+Argentina,https://www.youtube.com/watch?v=D6MpyFYpbs0,Disasters
+Argentina,http://www.lanacion.com.ar/1768844-violento-temporal-en-cordoba-seis-muertos-y-cientos-de-evacuados.  ,Disasters
+Argentina,http://www.buenosairesherald.com/article/201157/earthquake-in-salta-kills-a-94yearold-woman-injures-30,Disasters
+Argentina,http://reliefweb.int/sites/reliefweb.int/files/resources/LAC-Report-Weekly_Note_On_Emergencies-ROLAC-ENG-20150309-MR-16085.pdf,Disasters
+Argentina,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=8434.  ,Disasters
+Armenia,http://www.internal-displacement.org/europe-the-caucasus-and-central-asia/armenia/figures-analysis,Conflict and violence
+Australia,http://www.emknowledge.gov.au/resource/?id=3575,Disasters
+Australia,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/1598/xmps/1974,Disasters
+Australia,http://www.theage.com.au/victoria/house-washed-away-in-landslide-as-storms-heavy-rain-hit-victoria-20151208-gliv07.html,Disasters
+Australia,https://www.emknowledge.gov.au/resource/5652/2015/bushfire---adelaide-hills-south-australia-2015,Disasters
+Australia,http://edition.cnn.com/2015/02/19/world/australia-cyclone-marcia/,Disasters
+Australia,https://www.dcp.wa.gov.au/Resources/Documents/StatisticsForMedia/A5813084.pdf,Disasters
+Australia,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/5915/xmps/1974,Disasters
+Australia,http://www.theguardian.com/australia-news/2015/dec/26/great-ocean-road-bushfire-destroys-more-than-50-homes,Disasters
+Austria,http://newsinfo.inquirer.net/420141/10-dead-thousands-evacuated-as-floods-sweep-europe,Disasters
+Azerbaijan,http://reliefweb.int/sites/reliefweb.int/files/resources/26BED2D23AF41CDC4925741C00517813-Full_Report.pdf,Conflict and violence
+Bahamas; The,http://www.tribune242.com/news/2015/oct/22/hurricane-wiped-out-836-homes/?news,Disasters
+Bangladesh,http://saarc-sdmc.nic.in/pdf/saarc_news/news305.pdf,Disasters
+Bangladesh,http://www.nirapad.org.bd/admin/situation_report/1374128830_26_Flood_17.07.2013.pdf,Disasters
+Bangladesh,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2399/xmps/1974,Disasters
+Bangladesh,http://www.ifrc.org/docs/Appeals/15/IBBDfl160715.pdf,Disasters
+Bangladesh,http://www.chtdf.org/chtdf_files/chtdf_documents/Publications/Study%20Reports/Survey/Socio-economic_BaselineSurvey_CHT_%20HDRC_%2008April09.pdf,Conflict and violence
+Bangladesh,http://etheses.lse.ac.uk/270/1/Redclift%20Histories%20of%20displacement%20and%20the%20creation%20of%20political%20space%20%28public%20version%29.pdf,Conflict and violence
+Benin,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRBJ011.pdf,Disasters
+Bhutan,http://reliefweb.int/sites/reliefweb.int/files/resources/Abstract_Preliminary_Report_of_4th_April_2015_Windstorm.pdf,Disasters
+Bolivia,http://reliefweb.int/report/bolivia/bolivia-emergencia-nevadas-2013-oficina-del-coordinador-residente-reporte-de,Disasters
+Bolivia,http://www.iom.int/cms/en/sites/iom/home/news-and-views/press-briefing-notes/pbn-2014/pbn-listing/iom-builds-model-camps-after-flo.html#sthash.VKXOtdQL.dpuf,Disasters
+Bolivia,http://www.boliviaentusmanos.com/noticias/bolivia/93188/recuperan-a-la-ultima-victima-del-deslizamiento-de-rurrenabaque.html,Disasters
+Bolivia,http://www.elnuevodiario.com.ni/internacionales/310696,Disasters
+Bolivia,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/5669,Disasters
+Bolivia,http://reliefweb.int/sites/reliefweb.int/files/resources/WFP%20Bolivia%20Situation%20Report%20%2302%2C%2007%20September%202015.pdf.  ,Disasters
+Bosnia and Herzegovina,http://www.bbc.com/news/world-europe-28683200,Disasters
+Bosnia and Herzegovina,http://www.foxnews.com/world/2015/01/19/dozens-homes-flooded-in-bosnia-after-heavy-rainfall-many-for-fifth-time-in-20.html,Disasters
+Botswana,http://www.dailynews.gov.bw/news-details.php?nid=24693,Disasters
+Brazil,http://www.aljazeera.com/news/americas/2013/12/deadly-brazil-floods-leave-thousands-homeless-201312262341562228.html,Disasters
+Brazil,http://reliefweb.int/sites/reliefweb.int/files/resources/REDLAC%20Weekly%20Note%20on%20Emergencies%20Latin%20America%20%26%20the%20Caribbean%20Year%206%20Volume%20336.pdf,Disasters
+Brazil,https://www.disasterscharter.org/web/guest/-/article-id/ACT-492,Disasters
+Brazil,http://agenciabrasil.ebc.com.br/en/geral/noticia/2015-12/over-2200-households-affected-rainstorms-brazils-south-border,Disasters
+Brunei Darussalam,http://adinet.ahacentre.org/reports/view/218,Disasters
+Bulgaria,http://adore.ifrc.org/Download.aspx?FileId=62780,Disasters
+Burundi,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRBI011.pdf,Disasters
+Burundi,http://reliefweb.int/sites/reliefweb.int/files/resources/OIM%20Burundi%20DTM%20rapport%20%232.pdf,Conflict and violence
+Cabo Verde,http://reliefweb.int/sites/reliefweb.int/files/resources/UNDAC%20Rapid%20Assessment%20-%20Cabo%20Verde%20Volcano%209Dec2014.pdf,Disasters
+Cabo Verde,http://www.tvi24.iol.pt/internacional/01-09-2015/furacao-fred-provoca-estragos-em-cabo-verde,Disasters
+Cambodia,http://reliefweb.int/sites/reliefweb.int/files/resources/Cambodia_Sitrep06_08Nov2013%20%281%29.pdf,Disasters
+Cambodia,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=7229,Disasters
+Cambodia,http://adinet.ahacentre.org/reports/view/106,Disasters
+Cambodia,https://www.cambodiadaily.com/archives/storms-kill-four-people-destroy-dozens-of-homes-55878/,Disasters
+Cambodia,http://reliefweb.int/sites/reliefweb.int/files/resources/hrf_mulimaid_rapid_assessment-18_-19_sep_2015.pdf,Disasters
+Cameroon,https://www.humanitarianresponse.info/en/system/files/documents/files/dtm_cmr_report1_nov2015_en_0.pdf,Conflict and violence
+Canada,http://globalnews.ca/news/673236/by-the-numbers-2013-alberta-floods/,Disasters
+Canada,http://www.cbc.ca/news/canada/wildfires-force-evacuations-in-alberta-b-c-1.1300308,Disasters
+Canada,http://www.ec.gc.ca/meteo-weather/default.asp?lang=En&n=C8D88613-1&offset=4&toc=show,Disasters
+Canada,http://www.ec.gc.ca/meteo-weather/default.asp?lang=En&n=C8D88613-1&offset=15&toc=show,Disasters
+Canada,http://www.ec.gc.ca/meteo-weather/default.asp?lang=En&n=C8D88613-1&offset=3&toc=show,Disasters
+Canada,http://www.thebarrieexaminer.com/2014/10/23/province-wont-provide-relief-for-angus-tornado-victims,Disasters
+Canada,https://news.gov.bc.ca/stories/over-200-active-wildfires-impacting-province.  ,Disasters
+Central African Republic,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=7331#,Disasters
+Central African Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRCF014.pdf,Disasters
+Central African Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/Floods%20-%20DREF%20operation%20no%20MDRCF016%20Update%20No.1.pdf,Disasters
+Central African Republic,http://kangbindara.com/centrafriqueunepluiedilluviennefaitplusde500personnessansabrisabozoum/,Disasters
+Central African Republic,http://www.rjdhrca.net/actulites/actualite/banguiplusde25maisonsdetruitessuitealinondationdanslequartierbruxelles.html,Disasters
+Chad,http://reliefweb.int/report/chad/2082-houses-destroyed-rain-sudanese-refugee-camp,Disasters
+Chad,https://www.humanitarianresponse.info/en/system/files/documents/files/1_20151230_dtm_chiffre_de_deplaces_lac_tchad_rapport.pdf,Conflict and violence
+Chad,https://www.humanitarianresponse.info/fr/system/files/documents/files/chad_displacement_and_malnutrition_jt.pdf,Conflict and violence
+Chile,http://www.onemi.cl/informate/director-nacional-entrega-reporte-actualizado-por-sismo-de-mayor-intensidad/,Disasters
+Chile,http://www.onemi.cl/alerta/se-declara-alerta-roja-para-la-comuna-de-valparaiso-por-incendio-forestal-7/,Disasters
+Chile,http://noticias.lainformacion.com/catastrofes-y-accidentes/incendios/destruidas-24-viviendas-y-cien-evacuadas-por-incendio-forestal-en-valparaiso_HcS00htssgFuDu8kMUsAo3/,Disasters
+Chile,http://www.onemi.cl/alerta/monitoreo-alerta-roja-comunal-en-quilpue-por-incendio-forestal-2/,Disasters
+Chile,http://www.onemi.cl/noticia/oficina-nacional-de-emergencia-entrego-balance-por-situacion-de-incendios-forestales-en-zona-centro-sur-del-pais/,Disasters
+Chile,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/5770,Disasters
+Chile,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/5859,Disasters
+Chile,http://reliefweb.int/sites/reliefweb.int/files/resources/CL-Information_Note-Floods_Nothern_Region-20150415.pdf,Disasters
+Chile,http://reliefweb.int/sites/reliefweb.int/files/resources/Chile%20Earthquake%20Flash%20Note%20No%2001.pdf.  ,Disasters
+China,http://reliefweb/int/report/china/typhoon-kills-three-forces-evacuation-500000-china,Disasters
+China,http://reliefweb.int/report/china/death-toll-rises-94-nw-china-quake,Disasters
+China,https://www.ifrc.org/docs/Appeals/13/CHNTC230813.pdf,Disasters
+China,http://reliefweb.int/sites/reliefweb.int/files/resources/MAACN001DORQ3Q413.pdf,Disasters
+China,http://news/xinhuanet/com/english/china/2013-04/30/c_132350870/htm,Disasters
+China,http://www/huffingtonpost/com/2013/08/31/china-earthquake_n_3849234/html,Disasters
+China,http://reliefweb.int/report/china/china-earthquake-dref-operation-update-mdrcn005,Disasters
+China,http://reliefweb.int/report/china/150000-people-evacuated-s-china-downpour,Disasters
+China,http://news.xinhuanet.com/english/china/2013-04/17/c_132317791.htm,Disasters
+China,http://news/xinhuanet/com/english/china/2013-12/18/c_132977852/htm,Disasters
+China,http://news/xinhuanet/com/english/china/2013-01/13/c_132099883/htm,Disasters
+China,http://www.bbc.com/news/world-asia-china-23251188,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4672/xmps/1974,Disasters
+China,http://www.ifrc.org/docs/Appeals/rpts14/IBCNtc230714.pdf,Disasters
+China,http://floodlist.com/asia/floods-worsen-southern-central-china,Disasters
+China,http://news.xinhuanet.com/english/china/2014-07/17/c_133491802.htm,Disasters
+China,http://floodlist.com/asia/14-dead-337000-evacuated-southern-china-floods,Disasters
+China,http://news.xinhuanet.com/english/china/2014-07/27/c_133513497.htm,Disasters
+China,http://floodlist.com/asia/25-dead-7-days-flooding-china,Disasters
+China,http://floodlist.com/asia/chongqing-floods-continue-40-killed,Disasters
+China,http://earthquake-report.com/2014/02/12/very-strong-earthquake-southern-xinjiang-china-on-february-12-2014/,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2983/xmps/1974,Disasters
+China,http://news.xinhuanet.com/english/china/2014-10/08/c_133699636.htm,Disasters
+China,http://www.oxfam.org.hk/en/yunnanquake2014.aspx,Disasters
+China,http://news.xinhuanet.com/english/china/2014-05/11/c_133325839.htm,Disasters
+China,http://rt.com/news/china-earthquake-yongshan-yunnan-593/,Disasters
+China,http://www.chinadaily.com.cn/china/2014-04/01/content_17397992.htm,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash,Disasters
+China,http://news.xinhuanet.com/english/china/2014-06/16/c_133410912.htm,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2934/xmps/1974,Disasters
+China,http://news.xinhuanet.com/english/china/2014-05/10/c_133323971.htm,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-List/yy/2014/mm/11,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4282/xmps/1974,Disasters
+China,http://www.chinadaily.com.cn/china/2014-08/17/content_18408136.htm,Disasters
+China,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2404/xmps/1974,Disasters
+China,http://news.xinhuanet.com/english/china/2014-08/28/c_133591384.htm,Disasters
+China,http://news.xinhuanet.com/english/2015-03/31/c_134114074.htm,Disasters
+China,http://news.xinhuanet.com/english/2015-04/04/c_134125163.htm,Disasters
+China,http://floodlist.com/asia/china-over-100-died-in-natural-disasters-in-may-2015-as-more-floods-hit-south,Disasters
+China,http://floodlist.com/asia/china-floods-landslides-20-dead-june-2015,Disasters
+China,http://news.xinhuanet.com/english/2015-07/13/c_134405534.htm,Disasters
+China,http://www.scmp.com/news/china/society/article/1864851/death-toll-china-typhoon-mujigae-rises-19-state-media-says,Disasters
+China,http://news.xinhuanet.com/english/2015-11/15/c_134818576.htm,Disasters
+Colombia,http://reliefweb.int/report/colombia/aumentan-17-los-muertos-por-invierno-en-occidente-colombiano,Disasters
+Colombia,http://www.elcomercio.com/actualidad/colombia-evacua-familias-actividad-volcanes.html,Disasters
+Colombia,http://reliefweb.int/sites/reliefweb.int/files/resources/140611%20Humanitarian%20Bulletin%20May%202014%202.pdf,Disasters
+Colombia,http://www.salahumanitaria.co/es/system/files/documents/files/130114%20Informe%20de%20situaci%C3%B3n%20Sipi.pdf,Disasters
+Colombia,http://reliefweb.int/sites/reliefweb.int/files/resources/LAC-Report-Weekly_Note_On_Emergencies-ROLAC-ENG-20150525-MR-16488.pdf.  ,Disasters
+Colombia,https://www.humanitarianresponse.info/en/system/files/documents/files/snapshot_colombia_eng_jan_2016_conflict_1_1.pdf,Conflict and violence
+Comoros,http://reliefweb.int/report/madagascar/flash-update-thousands-affected-comoros-and-mozambique-alerts-lifted-madagascar,Disasters
+Comoros,http://reliefweb.int/sites/reliefweb.int/files/resources/ROSA_Com383v03_cyclone_hellen_snapshotA4_2014_04_18.pdf,Disasters
+Congo (Republic of),http://www.internal-displacement.org/sub-saharan-africa/congo/figures-analysis,Conflict and violence
+Costa Rica,http://www.huffingtonpost.com/2013/05/22/turrialba-volcano-spews-ash-costa-rica_n_3321356.html,Disasters
+Costa Rica,http://floodlist.com/america/costa-rica-flood-heredia-limon,Disasters
+Côte d'Ivoire,http://reliefweb.int/sites/reliefweb.int/files/resources/N1512776.pdf,Conflict and violence
+Croatia,"http://www.mvep.hr/en/info-servis/press-releases/floods-in-croatia-and-the-region---the-situation-analysis-on-28-may-2014,21657.html",Disasters
+Croatia,http://www.independent.mk/articles/19983/Croatia+Fire+Forces+Evacuation+of++People,Disasters
+Croatia,http://www.vijesti.rtl.hr/novosti/hrvatska/1793514/jakovina-se-ispricao-za-krivu-prognozu-pa-optuzio-jelica-na-poplavama-skuplja-jeftine-politicke-poene/#DevelopingStory-821,Disasters
+Cuba,http://floodlist.com/america/barocoa-cuba-second-severe-floods-week,Disasters
+Cyprus,http://internal-displacement.org/assets/library/Media/201505-Global-Overview-2015/20150506-global-overview-2015-en.pdf,Conflict and violence
+Cyprus,http://www.internal-displacement.org/europe-the-caucasus-and-central-asia/cyprus/figures-analysis,Conflict and violence
+Czech Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/Czech%20Republic%20MDRCZ002dfr.pdf,Disasters
+Dominica,http://reliefweb.int/sites/reliefweb.int/files/resources/UNICEF_Humanitarian_SitRep_StLucia_StVincent_Grenadines_Dominica_3Jan2014.pdf,Disasters
+Dominican Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/COE%20Boletin%20No.%2011%20Tormenta%20Tropical%20Chantal%206%20pm%20del%2012%20de%20julio.pdf,Disasters
+Dominican Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/COE%20Boletin%20No5%20Tormenta%20Gabrielle.pdf,Disasters
+Dominican Republic,http://www.listindiario.com/la-republica/2014/5/22/322935/Dos-provincias-en-alerta-roja-y-dos-en-amarilla-hay-unos-7076-desplazados,Disasters
+Dominican Republic,http://www.elcaribe.com.do/2014/08/25/lluvias-afectan-23-comunidades#sthash.yFupFRTW.dpuf,Disasters
+Dominican Republic,http://floodlist.com/america/1-dead-flooding-dominican-republic,Disasters
+Dominican Republic,http://floodlist.com/america/15000-evacuated-after-floods-in-dominican-republic,Disasters
+Dominican Republic,http://www.20minutos.com/noticia/26519/0/republica-dominicana/alerta-maxima/tormenta-erika/.  ,Disasters
+DR Congo,http://radiookapi.net/actualite/2013/08/09/equateur-des-milliers-de-sans-abris-apres-des-inondations-gbadolite/#.U2EQOoF_vng,Disasters
+DR Congo,http://radiookapi.net/actualite/2014/04/11/bukama-10-000-personnes-victimes-du-debordement-du-fleuve-congo/,Disasters
+DR Congo,http://www.rfi.fr/afrique/20141028-rdc-republique-democratique-congo-centaines-disparus-inondations-sud-kivu/,Disasters
+DR Congo,http://www.hirondelle.org/index.php/fr/nos-operations/programmes-actuels/republique-democratique-du-congo/a-la-une/360-radio-okapi-rdc-08-10-14-nord-kivu-plus-de-2-000-sinistres-a-la-suite-des-inondations-a-masisi,Disasters
+DR Congo,http://radiookapi.net/societe/2014/04/27/bas-congo-340-maisons-detruites-apres-des-inondations-tshela/,Disasters
+DR Congo,http://radiookapi.net/actualite/2014/11/04/province-orientale-2500-personnes-victimes-des-inondations-basoko/?utm_source=feedburner&utm_medium=fe...,Disasters
+DR Congo,http://radiookapi.net/actualite/2014/03/24/kindu-plus-de-200-maisons-detruites-par-une-forte-pluie/,Disasters
+DR Congo,http://radiookapi.net/environnement/2014/04/20/rdc-plus-de-200-maisons-inondees-a-kalemie/,Disasters
+DR Congo,http://radiookapi.net/actualite/2014/04/16/kasai-occidental-plus-de-60-maisons-inondees-dans-des-eaux-de-riviere-tshikapa/,Disasters
+DR Congo,http://radiookapi.net/actualite/2014/05/07/bunia-plus-de-60-maisons-detruites-apres-une-forte-pluie-kasenyi/,Disasters
+DR Congo,http://www.gdacs.org/report.aspx?eventtype=FL&eventid=4191,Disasters
+DR Congo,http://www.radiookapi.net/actualite/2015/03/30/sud-kivu-la-pluie-fait-14-morts-a-fizi,Disasters
+DR Congo,http://floodlist.com/africa/democratic-republic-congo-floods-kinshasa,Disasters
+DR Congo,http://news.trust.org//item/20151208175721-x64gf/,Disasters
+DR Congo,http://reliefweb.int/sites/reliefweb.int/files/resources/rdc_apercu_humanitaire_trim4_2015_fr.pdf,Conflict and violence
+Ecuador,http://www.ifrc.org/en/news-and-media/news-stories/americas/ecuador/silent-disasters-floods-bring-additional-challenges-to-vulnerable-communities-in-ecuador-60844/,Disasters
+Ecuador,http://www.elnuevoherald.com/2013/07/15/1521676/ecuador-200-evacuados-por-volcan.html,Disasters
+Ecuador,http://www.elcomercio.com/actualidad/ecuador/incendio-cerro-auqui-quito.html,Disasters
+Ecuador,http://www.elcomercio.com/actualidad/carchi-sismos-tulcan-alerta-naranja.html,Disasters
+Ecuador,http://reliefweb.int/report/ecuador/ecuador-villages-evacuated-cotopaxi-volcano-rumbles-life,Disasters
+Egypt,https://www.hrw.org/report/2015/09/22/look-another-homeland/forced-evictions-egypts-rafah,Conflict and violence
+Egypt,http://today.almasryalyoum.com/article2.aspx?ArticleID=470707,Conflict and violence
+Egypt,http://english.ahram.org.eg/NewsContent/1/64/142116/Egypt/Politics-/Egypt-has-complied-with-international-law-in-Sinai.aspx,Conflict and violence
+Egypt; Arab Rep.,http://www.thecairopost.com/news/101601/news/floods-and-heavy-rain-in-throughout-governorates-in-egypt-report,Disasters
+Egypt; Arab Rep.,http://www.albawaba.com/news/heavy-rain-flooding-kills-11-northern-egypt-100-evacuated-763998,Disasters
+El Salvador,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRSV006do_0.pdf,Disasters
+El Salvador,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=8362,Disasters
+El Salvador,http://www.uca.edu.sv/iudop/wp-content/uploads/INFORME-137.pdf,Conflict and violence
+El Salvador,http://cristosal.org/wp-content/uploads/2015/10/TranslatedcopyofinformefinalCIDH.pdf,Conflict and violence
+Eritrea,http://www.shabait.com/news/local-news/14342-heavy-rainfall-causes-flooding-in-haikota-sub-zone,Disasters
+Ethiopia,http://www.worldbulletin.net/world/146314/floods-displace-8000-ethiopian-families,Disasters
+Ethiopia,http://reliefweb.int/sites/reliefweb.int/files/resources/idmr_-_oct_to_dec_2015.pdf,Conflict and violence
+Fiji,http://www.fijitimes.com/story.aspx?id=261618,Disasters
+Finland,http://yle.fi/uutiset/flood_waters_swamp_pyhajoki_residents_evacuated/6588517,Disasters
+France,http://www.bfmtv.com/planete/inondations-sud-ouest-premier-bilan-542620.html,Disasters
+France,http://www.rivieratimes.com/index.php/provence-cote-dazur-article/items/south-west-france-swept-away-in-record-floods.html,Disasters
+France,http://www.bfmtv.com/planete/violents-orages-drome-foyers-prives-courant-630402.html,Disasters
+France,http://www.bfmtv.com/planete/inondations-haute-garonne-commune-saint-beat-coupee-monde-541044.html,Disasters
+France,http://floodlist.com/europe/floods-france-2013,Disasters
+France,http://www.bfmtv.com/planete/decrue-retour-a-normale-progressif-pied-pyrenees-543172.html,Disasters
+France,http://www.auxerretv.com/content/index.php?post/2013/05/04/Inondations-%3A-250-personnes-%C3%A9vacu%C3%A9es-pr%C3%A8s-de-Dijon#,Disasters
+France,http://www.courrierdelouest.fr/actualite/segre-eboulement-de-terrain-cinq-maisons-touchees-trois-sont-inhabitables-21-11-2013-13620,Disasters
+France,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-List/yy/2014/mm/12,Disasters
+France,http://erccportal.jrc.ec.europa.eu/ercmaps/ECDM_20140930_France_FlashFloods.pdf,Disasters
+France,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/1776/xmps/1974,Disasters
+France,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/1831/xmps/1974,Disasters
+France,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/3164/xmps/1974,Disasters
+France,http://www.theguardian.com/world/2015/oct/04/heavy-flooding-in-french-riviera-leaves-more-than-a-dozen-people-dead,Disasters
+Gabon,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=7218,Disasters
+Gabon,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=7553,Disasters
+Georgia,http://reliefweb.int/report/georgia/georgia-flash-floods-mdrge007-dref-operation-update-1,Disasters
+Georgia,http://adore.ifrc.org/Download.aspx?FileId=65647,Disasters
+Georgia,http://www.internal-displacement.org/europe-the-caucasus-and-central-asia/georgia/figures-analysis,Conflict and violence
+Germany,http://www.cedim.de/download/FDA_Juni_Hochwasser_Bericht2.pdf,Disasters
+Ghana,https://wca.humanitarianresponse.info/en/system/files/documents/files/IBGHfl02101301.pdf,Disasters
+Ghana,http://reliefweb.int/sites/reliefweb.int/files/resources/unct_sitrep-_accra_floods_08062015.pdf,Disasters
+Greece,http://www.reuters.com/article/2013/08/05/us-greece-fire-idUSBRE9740IW20130805,Disasters
+Greece,http://earthquake-report.com/2014/01/26/strong-earthquake-greece-on-january-26-2014/,Disasters
+Greece,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/1859/xmps/1974,Disasters
+Greece,http://earthquake-report.com/2014/05/24/strong-earthquake-aegean-sea-on-may-24-2014/,Disasters
+Guatemala,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRGT006DU1.pdf,Disasters
+Guatemala,http://floodlist.com/america/350-evacuated-after-heavy-rain-causes-landslide-in-guatemala.  ,Disasters
+Guatemala,http://reliefweb.int/sites/reliefweb.int/files/resources/IB03102015.pdf.  ,Disasters
+Guatemala,http://reliefweb.int/sites/reliefweb.int/files/resources/GT_Boletin_Informativo_No_4078.pdf.  ,Disasters
+Guatemala,http://reliefweb.int/sites/reliefweb.int/files/resources/Redhum_GT_Boletin_Informativo_No_4088_Afectadas_4_mil_216_personas_por_iInundaciones_en_Peten_y_Alta_Verapaz_CONRED-20151119-IC-17411-2.pdf.  ,Disasters
+Guatemala,http://reliefweb.int/sites/reliefweb.int/files/resources/LAC-Report-Weekly_Note_On_Emergencies-ROLAC-ENG-20150810-MR-16845.pdf.  ,Disasters
+Guatemala,http://www.internal-displacement.org/americas/guatemala/figures-analysis,Conflict and violence
+Guatemala,http://www.salanegra.elfaro.net/es/201110/cronicas/6451/,Conflict and violence
+Guinea,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRGN008.pdf,Disasters
+Haiti,http://www.undp.org/content/undp/en/home/presscenter/pressreleases/2014/11/12/undp-government-of-haiti-provide-immediate-support-to-flood-affected-victims/,Disasters
+Haiti,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/6049,Disasters
+Honduras,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4925/xmps/1974,Disasters
+Honduras,http://floodlist.com/america/nicaragua-honduras-floods-8-dead-june-2015,Disasters
+Honduras,http://www.latribuna.hn/2015/10/19/mas-de-200-familias-evacuadas-por-inundaciones/,Disasters
+Honduras,http://www.jips.org/files/1048,Conflict and violence
+Hungary,http://www.katasztrofavedelem.hu/index2.php?pageid=szervezet_flood_emergency&lang=eng#flash,Disasters
+India,http://reliefweb.int/report/india/cyclone-phailin-pummels-india-half-million-evacuated,Disasters
+India,http://www.oxfamindia.org/subpage/238,Disasters
+India,http://www.sdmassam.nic.in/pdf/flood_report/2014/Daily_Flood_Report_26.08.2014.pdf,Disasters
+India,http://in.reuters.com/article/2014/08/06/india-nepal-floods-idINKBN0G604X20140806,Disasters
+India,http://reliefweb.int/sites/reliefweb.int/files/resources/RJNA%20Report%20Part%20-1-Revised.pdf,Disasters
+India,http://www.christianaid.ie/emergencies/areas-of-concern/india-forceful-floods-hit-the-poorest-hardest.aspx,Disasters
+India,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4934/xmps/1974,Disasters
+India,http://timesofindia.indiatimes.com/india/Over-20000-evacuated-from-flood-hit-Vadodara/articleshow/42237243.cms,Disasters
+India,http://floodlist.com/asia/10000-displaced-assam-floods-june-2014,Disasters
+India,http://floodlist.com/asia/july-2014-madhya-pradesh-floods,Disasters
+India,http://timesofindia.indiatimes.com/india/Death-toll-in-Chhattisgarh-floods-reaches-three/articleshow/38933405.cms,Disasters
+India,http://thepeninsulaqatar.com/news/india/294994/15-families-evacuated-in-himachal-after-landslides,Disasters
+India,http://www.ndtv.com/cheat-sheet/srinagar-on-flood-alert-as-river-jhelum-crosses-danger-mark-750643,Disasters
+India,http://in.reuters.com/article/india-storm-idINKBN0NE1P420150423,Disasters
+India,http://tribune.com.pk/story/932063/at%ADleast%AD180%ADdead%ADa%ADmillion%ADdisplaced%ADin%ADindia%ADfloods/1/3/,Disasters
+India,http://www.asdma.gov.in/pdf/flood_report/2015/Daily_Flood_Report_22.08.2015.pdf,Disasters
+India,http://www.asdma.gov.in/pdf/flood_report/2015/Daily_Flood_Report_03.09.2015.pdf,Disasters
+India,http://indianexpress.com/article/cities/kolkata/dust-storm-in-bengal-leaves-200-homeless/,Disasters
+India,http://www.tribuneindia.com/news/nation/floods-wreak-havoc-claim-81-lives-in-three-states/114599.html,Disasters
+India,http://www.theshillongtimes.com/2015/03/31/contain-tribal-issue-in-nagaland-state-bjp-urges-govt/,Conflict and violence
+India,http://timesofindia.indiatimes.com/india/Rajnath-to-meet-Tripura-Mizoram-CMs-on-Bru-rehab/articleshow/46230660.cms,Conflict and violence
+India,http://pib.nic.in/newsite/PrintRelease.aspx?relid=106628,Conflict and violence
+India,http://timesofindia.indiatimes.com/india/JK-govt-approves-3000-posts-for-Kashmiri-pandits-under-PMs-package/articleshow/46527426.cms,Conflict and violence
+India,http://www.bbc.com/news/world-asia-india-30692286,Conflict and violence
+India,http://news.trust.org/item/20141010070859-g23bz?view=print,Conflict and violence
+India,http://ec.europa.eu/echo/files/funding/decisions/2014/HIPs/india_en.pdf,Conflict and violence
+India,http://www.achrweb.org/reports/india/AssamIDPs2014.pdf,Conflict and violence
+India,http://www.scribd.com/doc/254592636/Recent-Violence-Against-Adivasis-in-Assam-Report-of-a-Fact-Finding-Team-January-2015#scribd,Conflict and violence
+India,http://www.abc.net.au/news/2014-05-03/an-india-assam-violence/5428474,Conflict and violence
+India,http://www.thehindu.com/todays-paper/tp-national/situation-in-karbi-anglong-limping-back-to-normal/article5637600.ece,Conflict and violence
+India,http://khalracentre.org/wp-content/uploads/Report%20of%20the%20Fact%20Finding%20by%20Human%20Rights%20Law%20Network.pdf,Conflict and violence
+India,http://www.wing-india.org/wp-content/uploads/2014/09/Assam-Nagaland-border-conflict-final-2014-_1_pdf.pdf,Conflict and violence
+Indonesia,http://reliefweb.int/report/indonesia/flood-displaces-18000-indonesia,Disasters
+Indonesia,http://floodlist.com/asia/east-west-java-indonesia,Disasters
+Indonesia,http://www.bbc.com/news/world-asia-25548526,Disasters
+Indonesia,http://www.thejakartapost.com/news/2013/04/22/wary-gas-residents-still-evacuating-after-dieng-quake.html,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/63,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/212,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/20,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/130,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/17,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/142,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/135,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/166,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/211,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/228,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/244,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/16,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/207,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/10,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/33,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/15,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/147,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/189,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/102,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/154,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/53,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/59,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/215,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/116,Disasters
+Indonesia,http://adinet.ahacentre.org/reports/view/45,Disasters
+Indonesia,http://floodlist.com/asia/thousands-evacuated-floods-malaysia-indonesia,Disasters
+Indonesia,http://www.thejakartapost.com/news/2015/05/09/hundreds-flee-mt-karangetang-activity.html,Disasters
+Indonesia,http://reliefweb.int/sites/reliefweb.int/files/resources/ROAP_Snapshot_150720.pdf,Disasters
+Indonesia,http://america.aljazeera.com/articles/2015/9/25/indonesia-rocked-by-earthquake.html,Disasters
+Indonesia,http://aceh.antaranews.com/berita/27747/ribuan-warga-aceh-barat-mengungsi-akibat-banjir,Disasters
+Indonesia,http://www.www.mediaindonesia.com/mipagi/read/17841/Banjir-Rendam-9-Kabupaten-di-Aceh/2015/12/15,Disasters
+Indonesia,http://www.antaranews.com/en/news/99554/hundred-victims-of-tolikara-conflict-evacuated,Conflict and violence
+Indonesia,http://www.internal-displacement.org/south-and-south-east-asia/indonesia/figures-analysis,Conflict and violence
+Iran; Islamic Rep.,http://reliefweb.int/sites/reliefweb.int/files/resources/Information%20Bulletin%20no%202%20Iran%20Earthquake%2028%20November%202013.pdf,Disasters
+Iran; Islamic Rep.,http://reliefweb.int/report/iran-islamic-republic/information-bulletin-no-1-bushehr-earthquake-%E2%80%93-iran-april-2013,Disasters
+Iran; Islamic Rep.,https://www.eeri.org/wp-content/uploads/Mormori_Reconn_Rep_20_9_2014.pdf,Disasters
+Iran; Islamic Rep.,http://floodlist.com/asia/floods-iran-iraq-70-dead-cholera-outbreak,Disasters
+Iraq,http://www.talkradionews.com/united-nations/2013/02/07/iraq-flooding-un-responds.html#.U0Zrj6h_vng,Disasters
+Israel,http://www.jpost.com/National-News/Wildfires-break-out-across-Israel-for-2nd-day-311357,Disasters
+Israel,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2878/xmps/1974,Disasters
+Italy,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/5067/xmps/1974,Disasters
+Italy,http://www.rainews.it/dl/rainews/articoli/Maltempo-ciclone-sulla-Sardegna-Allagamenti-a-Olbia-Il-sindaco-Restate-a-casa-0f6882ef-d3dd-4a16-90d0-e259e5a46ef7.html,Disasters
+Italy,http://floodlist.com/europe/4-dead-as-heavy-rain-causes-floods-in-italy-and-balkans,Disasters
+Japan,http://www.bousai.go.jp/updates/h25ooame08/pdf/h25ooame08_10.pdf,Disasters
+Japan,http://www.bousai.go.jp/updates/h25typhoon18/pdf/h25typhoon18_8.pdf,Disasters
+Japan,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=7529,Disasters
+Japan,http://www.bousai.go.jp/updates/h25tsuyuki08/pdf/h25tsuyuki08_03.pdf,Disasters
+Japan,http://www.bousai.go.jp/updates/h2504awaji/pdf/h2504awaji08.pdf,Disasters
+Japan,http://www.japantimes.co.jp/news/2014/10/06/national/strong-typhoon-bearing-tokyo-area/#.VUoqco6qpBd,Disasters
+Japan,http://thewatchers.adorraeli.com/2014/08/09/typhoon-halong-to-make-landfall-in-southern-japan-grounds-flights/,Disasters
+Japan,http://www.bloomberg.com/news/2014-07-08/typhoon-neoguri-weakens-0n-track-toward-kyushu-island.html,Disasters
+Japan,http://www.bousai.go.jp/updates/h2627ooyuki/pdf/h2627ooyuki_03.pdf,Disasters
+Japan,http://mainichi.jp/english/articles/20150611/p2a/00m/0na/006000c,Disasters
+Japan,http://www.bousai.go.jp/updates/h270529kazan/pdf/h270619kazan_01.pdf,Disasters
+Japan,http://www.bousai.go.jp/updates/h27typhoon11/pdf/h27typhoon11_09.pdf,Disasters
+Japan,http://www.bousai.go.jp/updates/h27sakurajima/pdf/h27sakurajima_04.pdf,Disasters
+Japan,http://www.bousai.go.jp/updates/h27typhoon15/pdf/h27typhoon15_04.pdf,Disasters
+Japan,https://weather.com/storms/typhoon/news/tropical-storm-etau-japan-flooding-landslides,Disasters
+Japan,http://glidenumber.net/glide/public/search/details.jsp?glide=20561&record=2&last=129,Disasters
+Kazakhstan,http://reliefweb.int/sites/reliefweb.int/files/resources/ROCCA_00024_HSRC_20150716_ENG.pdf,Disasters
+Kazakhstan,http://floodlist.com/asia/kazakhstan-floods-1000-evacuated-almaty-region-july-2015,Disasters
+Kenya,http://webcache.googleusercontent.com/search?q=cache:j1PheI7t9rMJ:https://www.kenyaredcross.org/PDF/Appeals/Floods/Reconstruction%2520and%2520Response%2520on%2520aftermath%2520of%2520Floods%25202013.pdf+&cd=1&hl=fr&ct=clnk&gl=ch&client=safari,Disasters
+Kenya,http://www.nation.co.ke/counties/mombasa/300-left-homeless-as-mudslide-buries-houses-in-Jomvu/-/1954178/2545352/-/28l5c0z/-/index.html,Disasters
+Kenya,http://reliefweb.int/sites/reliefweb.int/files/resources/EA_Regional_Snapshot_20150211.pdf,Conflict and violence
+Kenya,http://www.standardmedia.co.ke/article/2000184111/final-phase-of-idps-resettlement-to-cost-the-government-over-sh4-48billion,Conflict and violence
+Korea; Dem. Rep.,http://radiookapi.net/actualite/2013/02/04/katanga-nouveau-bilan-des-pluies-malemba-nkulu-23-000-sans-abris/#.U2EMqYF_vng,Disasters
+Korea; Dem. Rep.,https://weather.com/storms/hurricane/news/typhoon-goni-impacts,Disasters
+Lao People's Democratic Republic,http://reliefweb.int/report/lao-peoples-democratic-republic/flooding-and-severe-weather-se-asia-september-2013,Disasters
+Lao People's Democratic Republic,http://adinet.ahacentre.org/reports/view/103?l=en_US,Disasters
+Lao People's Democratic Republic,http://reliefweb.int/sites/reliefweb.int/files/resources/RRF06-2015_Lao-PDR_Flood_Response.pdf,Disasters
+Lao People's Democratic Republic,http://adinet.ahacentre.org/reports/view/788,Disasters
+Lebanon,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRLB005do.pdf,Disasters
+Lebanon,http://reliefweb.int/sites/reliefweb.int/files/resources/Humanitarian%20Update%20-%20Issue%2015%20%2801%20December%202015%20-%20%2015%20January%202015%29_EN_web.pdf,Conflict and violence
+Lebanon,http://www.un.org/apps/news/story.asp?NewsID=51719#.VrMdVDbhA1g,Conflict and violence
+Libya,http://www.libyaherald.com/2013/05/03/emergency-aid-flown-to-flood-victims-in-the-south-east/#axzz35Xlo0g3L,Disasters
+Libya,http://www.libyaobserver.ly/news/500000-idps-are-need-urgent-humanitarian-assistance-libyan-red-crescent-says,Conflict and violence
+Madagascar,http://reliefweb.int/sites/reliefweb.int/files/resources/OCHA_ROSA_Humanitarian_Bulletin_Issue15_May2014.pdf,Disasters
+Madagascar,http://www.primature.gov.mg/cpgu/?p=211,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/21,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/51,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/203,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/220,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/42,Disasters
+Malaysia,http://adinet.ahacentre.org/reports/view/60,Disasters
+Malaysia,http://www.bt.com.bn/news-asia/2015/01/22/flood-situation-hits-sabah,Disasters
+Malaysia,http://floodlist.com/asia/malaysia-floods-3000-evacuate-december-2015,Disasters
+Malaysia,http://reliefweb.int/sites/reliefweb.int/files/resources/Weekly%2023-29%20Nov15_0.pdf,Disasters
+Malaysia,http://reliefweb.int/report/philippines/asean-weekly-disaster-update-21-27-december-2015,Disasters
+Mali,http://maliactu.net/mali-point-de-presse-hebdomadaire-de-la-minusma-13-aout/,Disasters
+Mali,https://www.humanitarianresponse.info/fr/system/files/documents/files/dtm_janvier_2016.pdf,Conflict and violence
+Marshall Islands,http://reliefweb.int/report/marshall-islands/ocha-flash-update-marshall-islands-king-tides-4-march-2014,Disasters
+Mauritius,http://www.govmu.org/English/News/Pages/Cyclone-Bansi-National-Disaster-Risk-Reduction-and-Management-Centre-submits-report.aspx,Disasters
+Mexico,http://newsinfo.inquirer.net/427651/severe-flooding-reported-in-mexican-border-city#ixzz320meKEgu,Disasters
+Mexico,http://news.discovery.com/earth/weather-extreme-events/flood-landslides-wreak-havoc-mexico-130921.htm,Disasters
+Mexico,http://www.redhum.org/emergencia_detail/tormenta-tropical-boris,Disasters
+Mexico,http://reliefweb.int/report/mexico/tropical-storm-batters-southern-mexico-coast-kills-six,Disasters
+Mexico,http://floodlist.com/america/mexico-floods-michoacan-guerrero-2-days-rain.  ,Disasters
+Mexico,http://www.jornada.unam.mx/ultimas/2015/10/20/inundaciones-y-deslizamientos-en-38-municipios-de-veracruz-4681.html.  ,Disasters
+Mexico,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/6779,Disasters
+Mexico,http://news.yahoo.com/heavy-rains-bring-flooding-mexicos-yucatan-143406082.html,Disasters
+Mexico,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/7647/xmps/1974,Disasters
+Micronesia; Fed. Sts.,https://www.usaid.gov/sites/default/files/documents/1866/maysak_fs01_04-06-2015.pdf,Disasters
+Morocco,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRMA006du1.pdf,Disasters
+Mozambique,http://reliefweb.int/sites/reliefweb.int/files/resources/Mozambique-UNRCO%20Situation%20Report%204%20-%2020130220.pdf,Disasters
+Mozambique,http://www.globaldtm.info/mozambique/,Disasters
+Myanmar,http://reliefweb.int/disaster/fl-2013-000087-mmr,Disasters
+Myanmar,http://reliefweb.int/report/myanmar/myanmar-humanitarian-bulletin-issue-06-1-%E2%80%93-31-jul-2013,Disasters
+Myanmar,http://reliefweb.int/sites/reliefweb.int/files/resources/Bulletin_Myanmar_Humanitarian_Sep2013.pdf,Disasters
+Myanmar,http://reliefweb.int/sites/reliefweb.int/files/resources/Bulletin_Humanitarian_OCHA_Aug2014.pdf,Disasters
+Myanmar,http://adinet.ahacentre.org/reports/view/84,Disasters
+Myanmar,http://adinet.ahacentre.org/reports/view/89,Disasters
+Myanmar,http://reliefweb.int/sites/reliefweb.int/files/resources/NNDMC%20sitrep%204%2020150902%20final.pdf,Disasters
+Myanmar,http://www.ifrc.org/en/news-and-media/news-stories/asia-pacific/myanmar/thousands-forced-to-evacuate-as-severe-floods-hit-rakhine-state--68992/,Disasters
+Myanmar,http://themimu.info/sites/themimu.info/files/documents/Snapshot_Humanitarian_OCHA_25Jan2016.pdf,Conflict and violence
+Namibia,http://reliefweb.int/report/namibia/heavy-rains-flood-villages,Disasters
+Namibia,http://www.namibiansun.com/environment/flooding-alert-for-kunene-river.63995,Disasters
+Nepal,http://reliefweb.int/sites/reliefweb.int/files/resources/IBSAregionfl080914.pdf,Disasters
+Nepal,http://floodlist.com/asia/landslide-flooding-nepal-india,Disasters
+Nepal,http://un.org.np/sites/default/files/PDNA-volume-B.pdf,Disasters
+Nepal,http://www.unhcr.org/50a9f82cb.html,Conflict and violence
+New Zealand,http://www.nzherald.co.nz/floods/news/article.cfm?c_id=205&objectid=11140679,Disasters
+New Zealand,http://hwe.niwa.co.nz/event/April_2013_Upper_North_Island_and_Nelson_Storm,Disasters
+New Zealand,http://www.nzherald.co.nz/nz/news/article.cfm?c_id=1&objectid=11468928,Disasters
+Nicaragua,http://floodlist.com/america/flood-nicaragua-worsens-24-dead-32000-displaced,Disasters
+Nicaragua,http://reliefweb.int/sites/reliefweb.int/files/resources/Nicaragua%20Emergencia%20Terremoto%20Reporte%20de%20Situacion%20No%203.pdf,Disasters
+Nicaragua,http://www.laprensa.com.ni/2015/12/02/departamentales/1946527-pobladores-volcan-momotombo,Disasters
+Niger,http://reliefweb.int/sites/reliefweb.int/files/resources/Inondations_03102014.pdf,Disasters
+Niger,http://reliefweb.int/report/niger/niger-humanitarian-dashboard-december-2015,Conflict and violence
+Nigeria,http://dailypost.ng/2014/09/30/flood-wreaks-havoc-ebonyi-destroys-200-houses/,Disasters
+Nigeria,http://nationalmirroronline.net/new/flood-displaces-200-families-in-katsina/,Disasters
+Nigeria,http://reliefweb.int/sites/reliefweb.int/files/resources/External%20Weekly%2023-30%20July%202014.pdf,Disasters
+Nigeria,http://floodlist.com/africa/ongoing-flooding-southern-nigeria-kills-15,Disasters
+Nigeria,http://allafrica.com/stories/201409020257.html,Disasters
+Nigeria,http://leadership.ng/features/386588/day-flood-ravaged-makurdi-communities-sent-100-packing,Disasters
+Nigeria,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/7099,Disasters
+Nigeria,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/7282,Disasters
+Nigeria,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/7533,Disasters
+Nigeria,http://nigeria.iom.int/sites/default/files/dtm/01_IOM%20DTM%20Nigeria_Round%20VII%20Report_20151223.pdf,Conflict and violence
+Norway,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/1610/xmps/1974,Disasters
+Norway,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4937/xmps/1974,Disasters
+Norway,http://erccportal.jrc.ec.europa.eu/ercmaps/ECDM_20140130_Norway_Fires.pdf,Disasters
+Norway,http://floodlist.com/europe/norway-record-rain-causes-flooding-in-south,Disasters
+Pakistan,http://www.balochistanexpressquetta.com/2014/04/16/first-anniversary-of-devastating-earthquake-in-mashkail/,Disasters
+Pakistan,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/7146,Disasters
+Pakistan,http://reliefweb.int/sites/reliefweb.int/files/resources/Special%20Report%20on%2030.04.2015.pdf,Disasters
+Pakistan,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/6466/xmps/1974,Disasters
+Pakistan,http://reliefweb.int/map/pakistan/pakistan-flood-impact-update-2-aug-2-015,Disasters
+Pakistan,http://www.ndma.gov.pk/dynamic/?p=2500,Disasters
+Pakistan,http://reliefweb.int/sites/reliefweb.int/files/resources/protection_cluster_quarterly_bulletin_october_-_december_2015.pdf,Conflict and violence
+Pakistan,http://www.internal-displacement.org/south-and-south-east-asia/pakistan/figures-analysis,Conflict and violence
+Palestine,http://www.unrwa.org/newsroom/press-releases/unrwa-declares-emergency-gaza-city-due-extreme-weather-and-flooding,Disasters
+Palestine,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRPS010dfr.pdf,Disasters
+Palestine,https://www.ochaopt.org/documents/press_release_170_palestinians_and_26_israelis_killed_in_2015_english.pdf,Conflict and violence
+Palestine,https://www.ochaopt.org/documents/hno_december29_final.pdf,Conflict and violence
+Palestine,http://www.badil.org/phocadownloadpap/Badil_docs/publications/Q&A-en.pdf,Conflict and violence
+Palestine,http://www.ochaopt.org/documents/ocha_opt_the_humanitarian_monitor_2014_05_29_english.pdf,Conflict and violence
+Palestine,http://www.btselem.org/download/200705_hebron_eng.pdf,Conflict and violence
+Panama,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4349/xmps/1974,Disasters
+Panama,http://www.sinaproc.gob.pa/nota-numero-1113.html,Disasters
+Panama,http://www.prensa.com/redaccion_de_prensa-com/personas-afectadas-lluvias-capital_0_4081841827.html,Disasters
+Papua New Guinea,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-List/yy/2014/mm/7,Disasters
+Papua New Guinea,http://www.iom.int/cms/en/sites/iom/home/news-and-views/press-briefing-notes/pbn-2014/pbn-listing/helping-cyclone-victims-in-papua.html,Disasters
+Papua New Guinea,http://floodlist.com/asia/floods-papua-new-guinea,Disasters
+Papua New Guinea,http://www.radionz.co.nz/international/pacific-news/241761/bougainville-red-cross-says-about-50-houses-wrecked-by-quake,Disasters
+Papua New Guinea,https://www.icrc.org/eng/resources/documents/news-release/2014/01-24-papua-new-guinea-violence.htm,Conflict and violence
+Papua New Guinea,http://www.internal-displacement.org/south-and-south-east-asia/papua-new-guinea/figures-analysis,Conflict and violence
+Paraguay,http://floodlist.com/america/paraguay-evacuation-asuncion-paraguay-river-overflows.  ,Disasters
+Paraguay,http://news.yahoo.com/five-dead-150-000-evacuated-latin-america-floods-175649848.html,Disasters
+Paraguay,http://reliefweb.int/report/paraguay/mil-200-familias-pierden-casas-y-cultivos-por-temporal-en-paraguay,Disasters
+Peru,http://www.indeci.gob.pe/objetos/alerta/MTAwNQ==/20141209183022.pdf,Disasters
+Peru,http://reliefweb.int/sites/reliefweb.int/files/resources/PE_RC%20Situation%20Report_01_Ubinas_Volcano_ENG.pdf,Disasters
+Peru,http://floodlist.com/america/rivers-overflow-ancash-huanuco-regions-peru,Disasters
+Peru,http://www.larepublica.pe/02-01-2014/huaico-deja-mas-de-100-afectados-en-distrito-quellouno#!foto2,Disasters
+Peru,http://elcomercio.pe/peru/ancash/desborde-rio-afecto-decenas-viviendas-ancash-noticia-1713109,Disasters
+Peru,http://floodlist.com/america/floods-displace-3000-san-martin-northern-peru,Disasters
+Peru,http://floodlist.com/america/peru-floods-landslides-5-regions-call-state-of-emergency.  ,Disasters
+Peru,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/5935/xmps/1974,Disasters
+Peru,http://floodlist.com/america/peru-floods-san-martin-december-2015,Disasters
+Peru,http://reliefweb.int/sites/reliefweb.int/files/resources/LAC-Report-Weekly_Note_On_Emergencies-ROLAC-ENG-20150914-MR-17015.pdf.  ,Disasters
+Peru,http://www.oimperu.org/sitehome/sites/default/files/Documentos/Desplazamientos_Internos.pdf,Conflict and violence
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1093/UPD%20SitRep%2011%20re%20Effects%20of%20SW%20Monsoon%20%2802OCT2013%29.pdf,Disasters
+Philippines,"http://www.ndrrmc.gov.ph/attachments/article/908/UPD%20re%20IMCP%20of%20310800H%20Jan-010600H%20Feb%202013,%2001-02-13,%206AM.pdf",Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/882/Update%20Sitrep%20No.4%20re%20Effects%20TD%20Bising.pdf,Disasters
+Philippines,"http://www.ndrrmc.gov.ph/attachments/article/1034/NDRRMC%20Update%20Sitrep%20No%203%20Effects%20of%20Earthquake%20at%20Carmen,%20Cotabato%20Province.pdf",Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1004/Update%20Incidents.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1037/UPD%20re%20Sitrep%20No.%203%20Effects%20of%20Intertropical%20Convergence%20Zone%20%28ITCZ%29%207June2013.pdf,Disasters
+Philippines,"http://www.ndrrmc.gov.ph/attachments/article/933/UPD%20SitRep%20No.13%20re%20Effects%20of%20TD%20Crising,%2024-02-13,%205PM.pdf",Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1073/doc01537820130818080057.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1101/UPD%20re%20SitRep%2010%20re%20Effects%20of%20ITCZ%20%2813OCT2013-6AM%29.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1091/UPD%20re%20SitRep%2011%20re%20Effects%20of%20Ty%20ODETTE%20%2825SEP2013%29.pdf,Disasters
+Philippines,"http://www.ndrrmc.gov.ph/attachments/article/871/UPD%20re%20SitRep%20No.4%20re%20Effects%20of%20TS%20Auring,%201-7-13.pdf",Disasters
+Philippines,"http://www.ndrrmc.gov.ph/attachments/article/1044/UPD%20re%20Effects%20of%20SW%20Monsoon%20&%20LPA%20in%20REGs%2011,%2012%20&%20ARMM%2019JUNE2013.PDF",Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/940/Binder1.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1054/sitrep%209%20update%20gorio.PDF,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1126/Update%20IMCP%20070800H-080800H.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/943/Update%20Incident%20Monitored%20242000H-250800H%20022513%208am.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1134/updLSincident.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1001/UPD%20Incidents%20Monitored%20Covering%20the%20Period%20020800H-021600H%20May%202013.PDF,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1033/Update%20I%20M%20C%20P%20030800H-031700H%2003%20June%202013%205pm.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1123/NDRRMC%20UPDATE%20IMcp%20050800%20-%20051800%20NOV%2013.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1293/Effects_of_Typhoon_Glenda_(RAMMASUN)_Final_Report_16SEP2014.pdf,Disasters
+Philippines,http://floodlist.com/asia/deaths-philippines-floods,Disasters
+Philippines,http://www.philstar.com/nation/2014/10/10/1378631/10000-families-displaced-floods-get-food-packs,Disasters
+Philippines,http://reliefweb.int/sites/reliefweb.int/files/resources/UPD%20re%20SitRep%203%20TS%20BASYANG%20%28%2801FEB2014%29%29.pdf,Disasters
+Philippines,http://reliefweb.int/sites/reliefweb.int/files/resources/SitRep%20No6%20Typhoon%20JOSE.pdf,Disasters
+Philippines,http://reliefweb.int/sites/reliefweb.int/files/resources/Update%20SitRep%20No.%203%20Effects%20of%20TD%20Caloy.pdf,Disasters
+Philippines,http://www.gmanetwork.com/news/story/377922/news/regions/ndrrmc-1-missing-in-wake-of-mindanao-flash-floods,Disasters
+Philippines,http://reliefweb.int/report/philippines/ndrrmc-sitrep-no10-re-effects-tropical-storm-amang-mekkhala,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1421/SitRep_No_09_re_Preparedness_Measures_for_TY_CHEDENG_(MAYSAK)_05APR2015_1800H.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/1441/Final_Report_re_Preparedness_Measures_for_Typhoon_DODONG_as_of_7-12MAY.pdf,Disasters
+Philippines,http://reliefweb.int/sites/reliefweb.int/files/resources/OCHAPhilippines%20Humanitarian%20Bulletin%20No6%20%28June%202015%29%20FINAL.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/index.php/8-ndrrmc-update/2487-situational-report-re-effect-of-enchanced-southwest-monsoon,Disasters
+Philippines,http://reliefweb.int/report/philippines/ndrrmc-update-sitrep-no-17-preparedness-measures-and-effects-typhoon-ineng-goni,Disasters
+Philippines,http://reliefweb.int/sites/reliefweb.int/files/resources/NDRRMC%20Update%20SitRep%20No%2010%20re%20Preparedness%20Measures%20and%20Effects%20of%20Tropical%20Storm%20Kabayan.pdf,Disasters
+Philippines,http://reliefweb.int/report/philippines/ndrrmc-update-sitrep-no18-re-preparedness-measures-tropical-storm-lando-koppu,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/2663/SitRep_No_16_re_Preparedness_Measures_and_Effects_of_Typhoon_NONA_21DEC2015_0600H.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/2665/Sitrep_No.08_re_Tropical_depression_ONYOK_22DECEMBER2015_0800H.pdf,Disasters
+Philippines,http://www.ndrrmc.gov.ph/attachments/article/2669/Northeast_Monsoon_21DEC2015_0600H.pdf,Disasters
+Philippines,http://www.protectionclusterphilippines.org/wp-content/uploads/2015/07/2015-Mindanao-Mid-Year-Displacement-Dashboard-Issue-No.-17.pdf,Conflict and violence
+Philippines,http://www.protectionclusterphilippines.org/wp-content/uploads/2015/11/October-Mindanao-Displacement-Dashboard.pdf,Conflict and violence
+Philippines,https://www.humanitarianresponse.info/en/system/files/documents/files/ochaphilippines_humanitarian_bulletin_no1_january_2016_final.pdf,Conflict and violence
+Philippines,https://www.icrc.org/en/download/file/18047/philippines-operational_highlights_2015.pdf,Conflict and violence
+Portugal,http://www.tvi24.iol.pt/sociedade/chuva/mau-tempo-nos-acores-45-casas-inundadas-e-estradas-cortadas,Disasters
+Romania,http://www.reuters.com/article/2014/08/03/us-bulgaria-flood-idUSKBN0G306Y20140803,Disasters
+Romania,http://floodlist.com/europe/4-killed-romania-floods,Disasters
+Romania,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/6405,Disasters
+Russian Federation,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRRU017do.pdf,Disasters
+Russian Federation,http://www.belarus.by/en/press-center/press-release/belarus-to-build-65-houses-in-flood-hit-amur-oblast_i_0000010121.html,Disasters
+Russian Federation,http://www.internal-displacement.org/europe-the-caucasus-and-central-asia/russian-federation/figures-analysis,Conflict and violence
+Rwanda,http://reliefweb.int/report/rwanda/disaster-affected-families-kirehe-get-relief,Disasters
+Rwanda,http://www.panapress.com/Graves-inondations-dans-le-Nord-ouest-du-Rwanda--13-868309-18-lang1-index.html,Disasters
+Rwanda,http://allafrica.com/stories/201509040781.html,Disasters
+Samoa,http://www.samoanews.com/content/en/asg-and-red-cross-come-aid-flood-victims,Disasters
+Samoa,http://www.pacificdisaster.net/pdnadmin/data/original/WSM_20151128_TD03F_MNRE_Sitrep2.pdf,Disasters
+Senegal,http://reliefweb.int/report/senegal/senegal-humanitarian-overview-17-september-2015,Conflict and violence
+Serbia,http://ec.europa.eu/enlargement/pdf/press_corner/floods/20140715-serbia-rna-report.pdf,Disasters
+Serbia,http://reliefweb.int/sites/reliefweb.int/files/resources/Serbia%20Flash%20Floods%20Emergency%20Plan%20of%20Action%20Operation%20n%20MDRRS008.pdf,Disasters
+Serbia,http://reliefweb.int/sites/reliefweb.int/files/resources/ECDM_20140131_EasternCentralEurope_SevereWeather.pdf,Disasters
+Solomon Islands,http://www.abc.net.au/news/2014-04-07/an-thousands-in-evacuation-centres-as-solomon-islands-counts-th/5371882,Disasters
+Somalia,http://floodlist.com/africa/floods-worsen-somalia-leaving-21000-homeless,Disasters
+Somalia,http://www.radioergo.org/en/read.php?article_id=1373,Disasters
+Somalia,http://www.radioergo.org/en/read.php?article_id=1394,Disasters
+Somalia,https://www.sheltercluster.org/sites/default/files/docs/20150606_somalia_factsheet_may.pdf,Disasters
+Somalia,https://www.sheltercluster.org/sites/default/files/docs/20150715somalia_factsheet_june_final.pdf,Disasters
+Somalia,http://reliefweb.int/sites/reliefweb.int/files/resources/Somalia%20Humanitarian%20Dashboard%20-%20December%202015.pdf,Conflict and violence
+South Africa,https://www.enca.com/south-africa/reports-evacuations-fire-rages-near-cape-town-suburbs,Disasters
+South Sudan,http://www.voanews.com/content/flooding-south-sudan/1748143.html,Disasters
+South Sudan,http://reliefweb.int/report/south-sudan-republic/over-15000-displaced-fresh-floods,Disasters
+South Sudan,http://floodlist.com/africa/60000-displaced-floods-sudan-south-sudan,Disasters
+South Sudan,http://www.sudantribune.com/spip.php?iframe&page=imprimable&id_article=52682,Disasters
+South Sudan,http://floodlist.com/africa/floods-worsen-suffering-south-sudan,Disasters
+South Sudan,http://www.sudantribune.com/spip.php?article52746,Disasters
+South Sudan,http://www.gdacs.org/report.aspx?eventtype=FL&eventid=4186,Disasters
+South Sudan,http://sudantribune.com/spip.php?article56351,Disasters
+South Sudan,https://www.google.ch/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwjZ_4Dvk-vLAhXTbZoKHU_yA5IQFggfMAA&url=http%3A%2F%2Freliefweb.int%2Fsites%2Freliefweb.int%2Ffiles%2Fresources%2FUNHCRSouthSudan_YearinReview2015.pdf&usg=AFQjCNH7Zc0UZrpFLzOUFzdxCFpc8RBwFg,Conflict and violence
+Spain,http://www.presstv.com/detail/2013/08/23/320149/100s-battle-raging-forest-fire-in-spain/,Disasters
+Spain,http://www.catalannewsagency.com/society-science/item/severe-floods-in-the-north-western-catalan-pyrenees,Disasters
+Spain,http://www.bbc.com/news/world-europe-23491004,Disasters
+Spain,http://www.typicallyspanish.com/news-spain/blanca/A_fire_in_J_vea_resulted_in_1_400_people_being_evacuated_last_night.shtml,Disasters
+Spain,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/4565/xmps/1974,Disasters
+Spain,http://www.telegraph.co.uk/news/worldnews/europe/spain/10934757/Hundreds-flee-wildfire-in-Spains-Costa-del-Sol.html,Disasters
+Spain,http://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_2358925.html,Disasters
+Spain,http://ccaa.elpais.com/ccaa/2014/05/14/valencia/1400067803_042604.html,Disasters
+Spain,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/3064/xmps/1974,Disasters
+Spain,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/2812/xmps/1974,Disasters
+Sri Lanka,http://reliefweb.int/report/sri-lanka/seven-killed-floods-mudslides-sri-lanka,Disasters
+Sri Lanka,http://reliefweb.int/sites/reliefweb.int/files/resources/ROAP_sitmap_141229.pdf,Disasters
+Sri Lanka,http://reliefweb.int/sites/reliefweb.int/files/resources/Current-Sitiation_43.pdf,Disasters
+Sri Lanka,http://resettlementmin.gov.lk/site/images/stories/pdf/per2015e.pdf,Conflict and violence
+Sudan,https://www.ifrc.org/docs/Appeals/13/MDRSD01802.pdf,Disasters
+Sudan,http://www.ifrc.org/en/news-and-media/news-stories/africa/sudan/heavy-rains-and-flash-floods-in-sudan-66633/,Disasters
+Sudan,http://allafrica.com/stories/201508051322.html,Disasters
+Sudan,http://allafrica.com/stories/201508051510.html,Disasters
+Sudan,"http://www.refworld.org/country,,,,SDN,,56a78af44,0.html",Conflict and violence
+Sudan,https://sudan.iom.int/sites/default/files/docs/DTM%20Dashboard%20Jan-Jun%202015%20final.pdf,Conflict and violence
+Sudan,https://sudan.iom.int/sites/default/files/docs/IOM%20Sudan%20DTM%20Dashboard%202015.pdf,Conflict and violence
+Suriname,http://www.trust.org/item/20130613133739-o9heu/?source=shem,Disasters
+Sweden,http://online.wsj.com/articles/thousands-evacuated-one-dead-as-swedens-forest-fire-rages-on-1407230183,Disasters
+Sweden,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/7269,Disasters
+Switzerland,http://www.news24.com/World/News/Floods-wreak-havoc-in-Switzerland-20130610,Disasters
+Syria,http://www.aljazeera.com/news/middleeast/2014/10/syrian-refugees-at-risk-from-floods-201410219127711747.html,Disasters
+Syria,https://www.humanitarianresponse.info/en/system/files/documents/files/2016_hno_syrian_arab_republic.pdf,Conflict and violence
+Taiwan; China,http://www.theaustralian.com.au/news/latest-news/typhoon-trami-batters-china/story-fn3dxix6-1226702202958,Disasters
+Taiwan; China,http://www.afp.com/en/node/2861678,Disasters
+Taiwan; China,http://www.nfa.gov.tw/uploads/2/2015071104034th%20Emergency%20Report%20of%20Typhoon%20Chanhom.pdf,Disasters
+Taiwan; China,http://www.nfa.gov.tw/uploads/2/2015081206289th%20Emergency%20Report%20of%20Typhoon%20Soudelor.pdf,Disasters
+Taiwan; China,http://www.nfa.gov.tw/uploads/2/201508240900%E8%8B%B1%E8%AD%AF-10408231700%E5%A4%A9%E9%B5%9D%E9%A2%B1%E9%A2%A8%E7%81%BD%E5%AE%B3%E6%87%89%E8%AE%8A%E8%99%95%E7%BD%AE%E5%A0%B1%E5%91%8A%E7%AC%AC3%E5%A0%B1(%E6%A0%B8%E5%AE%9A).pdf,Disasters
+Taiwan; China,http://www.nfa.gov.tw/uploads/2/2015092911174th%20Emergency%20Report%20of%20Typhoon%20Dujuan.pdf,Disasters
+Tajikistan,http://reliefweb.int/sites/reliefweb.int/files/resources/South%20Caucasus%20and%20Central%20Asia%20-%20Humanitarian%20Bulletin%20Issue%203%20-%20January-June%202014.pdf,Disasters
+Tajikistan,http://reliefweb.int/sites/reliefweb.int/files/resources/MDRTJ017do.pdf,Disasters
+Tanzania,http://www.ifrc.org/docs/Appeals/14/MDRTZ015.pdf,Disasters
+Tanzania,http://www.trcs.or.tz/article/115/Latest-info-on-flooding-in-Dar-Es-Salaam,Disasters
+Tanzania,http://floodlist.com/africa/1000-displaced-flooding-arusha-tanzania,Disasters
+Tanzania,http://24tanzania.com/tanga-floods-leave-families-homeless/,Disasters
+Tanzania,http://www.ippmedia.com/frontend/index.php?l=66815,Disasters
+Thailand,http://reliefweb.int/report/thailand/600-houses-buriram-under-water,Disasters
+Thailand,http://www.trust.org/item/20130923055308-11zh4/?source=hpbreaking,Disasters
+Thailand,http://reliefweb.int/report/thailand/tropical-storms-ravage-northeast,Disasters
+Thailand,http://reliefweb.int/report/thailand/150-houses-destroyed-surin-was-hit-storms,Disasters
+Thailand,http://reliefweb.int/report/thailand/tropical-storm-sweeps-trat-destroys-30-houses-and-school,Disasters
+Thailand,http://reliefweb.int/report/thailand/summer-storm-sweeps-nakhon-si-thammarat-destroys-houses-and-factories,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5705060010003,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5704070010001,Disasters
+Thailand,http://reliefweb.int/report/thailand/northeastern-provinces-slammed-summer-storm,Disasters
+Thailand,http://reliefweb.int/report/thailand/hailstorms-hit-phu-ruea-district-loei-province-devastating-400-families,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5704280010001,Disasters
+Thailand,http://floodlist.com/asia/thailand-floods-nine-provinces,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5710220010001,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5711110010011,Disasters
+Thailand,http://reliefweb.int/report/thailand/chiang-rai-hit-floods,Disasters
+Thailand,http://adinet.ahacentre.org/reports/view/150,Disasters
+Thailand,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-List/yy/2014/mm/10,Disasters
+Thailand,http://thainews.prd.go.th/centerweb/newsen/NewsDetail?NT01_NewsID=WNDAT5704040010002,Disasters
+Thailand,http://thainews.prd.go.th/website_en/news/news_detail/WNSOC5808310010001,Disasters
+Thailand,http://www.crisisgroup.org/~/media/Files/asia/south-east-asia/thailand/140_southern_thailand___the_problem_with_paramilitaries,Conflict and violence
+Togo,http://togoportail.net/spip.php?page=imprimir_articulo&id_article=4055,Disasters
+Togo,http://floodlist.com/africa/deadly-floods-west-africa-togo-benin-ghana,Disasters
+Togo,http://www.internal-displacement.org/sub-saharan-africa/togo/figures-analysis,Conflict and violence
+Togo,http://www.brookings.edu/~/media/research/files/papers/2012/1/ecowas-ferris-stark/01_ecowas_ferris_stark.pdf,Conflict and violence
+Tonga,http://www.worldbank.org/en/news/feature/2014/12/17/tonga-survivors-get-back-on-their-feet-after-tropical-cyclone-ian,Disasters
+Tunisia,"http://www.businessnews.com.tn/inondations-a-jendouba--120-habitants-evacues,520,53962,3",Disasters
+Turkey,http://www.dailysabah.com/nation/2015/02/02/hundreds-evacuated-due-to-floods-in-edirne,Disasters
+Turkey,http://www.internal-displacement.org/europe-the-caucasus-and-central-asia/turkey/figures-analysis,Conflict and violence
+Tuvalu,http://www.unicef.org/appeals/files/UNICEF_Pacific_Cyclone_Pam_SitRep_15Mar2015.pdf,Disasters
+Uganda,http://www.wsj.com/articles/uganda-floods-destroy-crops-1410860907,Disasters
+Uganda,http://floodlist.com/africa/16000-displaced-uganda-river-semliki-overflows,Disasters
+Uganda,http://www.monitor.co.ug/News/National/Red-Cross-appeals-for-help-as-floods-displace-1500/-/688334/2990208/-/14odf25/-/index.html,Disasters
+Uganda,http://www.unhcr.org/4f0718269.html,Conflict and violence
+United Kingdom,http://www.theguardian.com/uk-news/2013/dec/06/east-coast-britain-hit-tidal-surge-floods-weather-live-updates,Disasters
+United Kingdom,http://www.huffingtonpost.co.uk/2013/10/28/girl-killed-storm-kent_n_4169146.html,Disasters
+United Kingdom,http://www.express.co.uk/news/weather/624185/Weekend-weather-forecast-flood-alert-UK-months-rain-48-hours,Disasters
+United Kingdom,http://www.bbc.com/news/uk-35181139,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/08/07/file_attachments/230303/20130807+FEMA+Daily+Ops+Briefing_0830.pdf,Disasters
+United States,http://www.weather.com/news/tornado-central/tornado-oklahoma-city-suburb-20130520,Disasters
+United States,http://www.fema.gov/media-library-data/1389885723065-305f14d3dfb03e835eba18827d78b289/PDA+Report+FEMA-4159-DR-TX.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/02/10/file_attachments/189997/20130210%2BFEMA%2BDaily%2BOps%2BBriefing_0830.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/07/08/file_attachments/223666/20130708+FEMA+Daily+Ops+Briefing_0830.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/e586b5ace71db648f9ff9224a4519e94/PDA_Report_FEMA-4144-DR-MO.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/20130726-1908-25045-8641/dhs_ocfo_pda_report_fema_4102_dr_la.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/06/17/file_attachments/218852/20130617%2BFEMA%2BDaily%2BOps%2BBriefing_0830.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/08/14/file_attachments/231535/20130814+FEMA+Daily+Ops+Briefing_0830.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/eebe3f288267036e8423a052169e7bd9/PDA_Report_FEMA-4132-DR-WV.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/06/01/file_attachments/215093/20130601%2BFEMA%2BDaily%2BOps%2BBriefing_0830.pdf,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/06/29/file_attachments/222254/20130629+FEMA+Daily+Ops+Briefing_0830.pdf,Disasters
+United States,http://www.huffingtonpost.com/2013/10/04/wayne-nebraska-tornado-storm-plains_n_4047259.html,Disasters
+United States,http://content.govdelivery.com/attachments/USDHSFEMA/2013/08/08/file_attachments/230471/20130808+FEMA+Daily+Ops+Briefing_0830.pdf,Disasters
+United States,http://www.washingtonpost.com/national/colby-fire-continues-to-burn-above-glendora-outside-los-angeles/2014/01/17/3b82a816-7f88-11e3-93c1-0e888170b723_story.html,Disasters
+United States,http://www.fema.gov/media-library-data/1398965702019-c0bd5bbda0723e3fe093a8e187f718d0/FY14%20DHS-OCFO%20PDA%20Report%20FEMA-4168-DR-WA.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/1403803041456-f7554e4a06fbd33552d7cc3f88b9e677/PDA+Report+Denial+-+NC.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/1401994619007-65d63612e17856aba71f09be6b84069a/FY14%20DHS-OCFO%20PDA%20Report%20FEMA-4177-DR-FL%20(Autosaved).pdf,Disasters
+United States,http://floodlist.com/america/usa/floods-south-dakota-iowa-minnesota,Disasters
+United States,http://www.ncdc.noaa.gov/stormevents/eventdetails.jsp?id=518334,Disasters
+United States,http://sandiegofreepress.org/2014/06/extreme-weather-watch-june-2014-torrential-rains-baseball-sized-hail-massive-midwest-flooding-2/,Disasters
+United States,http://www.fema.gov/media-library-data/1410360357274-344b411e635f0d8c2010817100553055/PDA%20Report%20FEMA-4188-DR-WA.pdf,Disasters
+United States,http://www.ktvl.com/template/cgi-bin/archived.pl?type=basic&file=/shared/news/top-stories/stories/archive/2014/08/J7dtLGfH.xml,Disasters
+United States,http://www.theguardian.com/world/2014/aug/07/oregon-wildfire-evacuations-california-washington-forest-burn,Disasters
+United States,http://abc7news.com/news/thousands-stranded-1-dead-in-california-mudslides/238706/#&cmp=twi-kgo-post-238706,Disasters
+United States,http://www.fema.gov/media-library-data/1414004530838-760d1e8c7a3fabc466015992ea108490/PDA%20Report%20FEMA-4195-DR-MI.pdf,Disasters
+United States,"http://www.capradio.org/articles/2014/09/10/happy-camp-complex-fire-claims-homes,-evacuation-orders-may-be-expanded/",Disasters
+United States,http://www.fema.gov/media-library-data/1414004912034-6facfe99263d4f14a59953686a5681c5/PDA%20Report%20FEMA-4196-DR-KY.pdf,Disasters
+United States,http://www.usatoday.com/story/news/nation/2014/08/24/napa-valley-earthquake/14524035/,Disasters
+United States,http://www.fema.gov/media-library-data/1415980907972-7185a1bc6fd39b26b66316011af1552f/PDA%20Report%20Appeal%20Denial%20-%20HI.pdf,Disasters
+United States,http://earthobservatory.nasa.gov/NaturalHazards/view.php?id=84397,Disasters
+United States,http://www.fresnobee.com/2014/10/02/4157684_madera-sheriff-man-burning-deer.html?rh=1,Disasters
+United States,https://caloesnewsroom.wordpress.com/2014/10/08/applegate-fire-fmag/,Disasters
+United States,http://www.bbc.com/news/world-us-canada-30460742,Disasters
+United States,http://losangeles.cbslocal.com/2014/12/11/looming-storm-spurs-issuance-of-mandatory-evacuation-order-for-1000-glendora-residents/,Disasters
+United States,http://www.fema.gov/media-library-data/1433189309339-2ae14d4562b124e9cf5f56aced53dbb6/PDAReportFEMA4217DRKY.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/1433963729857-d1d4b9786ac9e86c56051747fab46a0e/PDAReportFEMA4223DRTX.pdf.  ,Disasters
+United States,http://www.fema.gov/media-library-data/1433963567975-0b9c04a12168776d11505cdf41448ffd/PDAReportFEMA4222DROK.pdf,Disasters
+United States,http://www.fema.gov/media-library-data/1437591725420-30faa740a438081f44d81406bc3784c4/PDAReportFEMA4226DRAR.pdf.  ,Disasters
+United States,http://www.fema.gov/media-library-data/1442842947429-110caa0d08d7dd20e633330521d1b009/PDAReportFEMA4239DRKY.pdf,Disasters
+United States,http://www.kcra.com/california-wildfires/lake-countys-rocky-fire-containment-increases-again/34569610.  ,Disasters
+United States,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/Echo-Flash-Item/oid/6944/xmps/1974.  ,Disasters
+United States,http://www.reuters.com/article/us-usa-weather-floods-idUSKCN0RZ1UD20151006.  ,Disasters
+United States,http://www.fema.gov/media-library-data/1448984368526-692a625cc2e876f46ceecf7c1dd3783a/PDAReportFEMA4245DRTX.pdf.  ,Disasters
+United States,http://www.fema.gov/media-library-data/1456155387217-0f5c7dcc355f184a0092fb6aff084845/PDAReportFEMA4248DRMS.pdf,Disasters
+United States,http://edition.cnn.com/2015/09/15/us/california-wildfires/index.html.  ,Disasters
+United States,http://www.fema.gov/media-library-data/1442240559852-1456d6ebcfbba3a5cbe773ed2aea6c76/PDAReportFEMA4238DRMO.pdf,Disasters
+Uruguay,http://www.elpais.com.uy/informacion/aumentan-evacuados-debido-registro-hay.html,Disasters
+Uruguay,http://www.elpais.com.uy/informacion/rio-uruguay-crecer-enciende-alarmas.html,Disasters
+Uruguay,http://www.sne.gub.uy/index.php?option=com_content&view=article&id=759:riesgo-de-inundacion-en-el-litoral-del-pais&catid=9:rota-noticias,Disasters
+Uruguay,http://reliefweb.int/report/uruguay/23571-personas-desplazadas-causa-de-las-inundaciones-contin-el-operativo-retorno-en,Disasters
+Vanuatu,http://floodlist.com/australia/1-dead-hundreds-evacuated-vanuatu-record-rainfall,Disasters
+Venezuela; RB,http://reliefweb.int/sites/reliefweb.int/files/resources/Redhum_LAC_Sistema_ONU_Informe_de_situacion_No_2_IInundaciones_al_9_de_Julio-20150709-MA-16696.pdf.  ,Disasters
+Venezuela; RB,http://floodlist.com/america/venezuela-floods-river-overflows-trujillo.  ,Disasters
+Vietnam,http://reliefweb.int/report/viet-nam/toll-vietnam-floods-rises-34-official,Disasters
+Vietnam,http://www.vietnamcolors.net/2013/09/typhoon-hits-vietnam-after-leaving-dozens-missing/,Disasters
+Vietnam,http://reliefweb.int/report/philippines/asia-and-pacific-weekly-regional-humanitarian-snapshot-16-22-sep-2015,Disasters
+Vietnam,http://reliefweb.int/sites/reliefweb.int/files/resources/ROAP_sitmap_141201.pdf,Disasters
+Vietnam,http://floodlist.com/asia/vietnam-rammasun-floods-update,Disasters
+Vietnam,http://adinet.ahacentre.org/reports/view/87,Disasters
+Vietnam,http://adinet.ahacentre.org/reports/view/99#discussion,Disasters
+Vietnam,http://adinet.ahacentre.org/reports/view/61,Disasters
+Vietnam,http://floodlist.com/asia/flash-floods-son-la-province-vietnam-june-2015,Disasters
+Vietnam,https://www-secure.ifrc.org/DMISII/pages/02_Disaster_tracking/02011_form_read.aspx?repid=8336#,Disasters
+Vietnam,http://vietnamnews.vn/society/278130/heavy-rain-kills-8-in-central-viet-nam.html,Disasters
+Yemen,http://reliefweb.int/sites/reliefweb.int/files/resources/Yemen%202013%20August%20Floods%20report%20no%202%20%281%29.pdf,Disasters
+Yemen,https://yemen.humanitarianresponse.info/system/files/documents/files/OCHA%20Yemen%20Humanitarian%20Bulletin%20Issue%2020%20-%206%20October%20to%205%20November%202013.pdf,Disasters
+Yemen,http://reliefweb.int/sites/reliefweb.int/files/resources/tfpm_6th_report_10_december_2015.pdf,Conflict and violence
+Zambia,http://lusakavoice.com/2013/02/15/zanis-copy-dmmu-distributes-tents-to-662-homeless-families-in-mumbwa/,Disasters
+Zambia,http://lusakavoice.com/2014/03/26/govt-distributes-relief-food-in-kaputa/,Disasters
+Zambia,https://www.daily-mail.co.zm/?p=14793,Disasters
+Zambia,http://lusakavoice.com/2015/01/01/2-govt-pledges-support-to-chitukuko-victims/,Disasters
+Zambia,http://allafrica.com/stories/201402250488.html,Disasters
+Zambia,https://www.daily-mail.co.zm/?p=54115,Disasters
+Zimbabwe,http://floodlist.com/africa/zimbabwe-tokwe-mukorsi-flood-victims-suffer-human-rights-violations,Disasters
+Zimbabwe,http://erccportal.jrc.ec.europa.eu/ECHO-Flash/ECHO-Flash-Item/oid/5356,Disasters

--- a/internal_displacement/extracted_report.py
+++ b/internal_displacement/extracted_report.py
@@ -24,15 +24,11 @@ def convert_quantity(value):
 
 class ExtractedReport:
 
-    def __init__(self, locations, date_times, event_term, subject_term, quantity, story, tag_spans=[]):
+    def __init__(self, locations, event_term, subject_term, quantity, story, tag_spans=[]):
         if locations:
             self.locations = [convert_tokens_to_strings(l) for l in locations]
         else:
             self.locations = []
-        if date_times:
-            self.date_times = date_times
-        else:
-            self.date_times = []
         self.event_term = convert_tokens_to_strings(event_term)
         self.subject_term = convert_tokens_to_strings(subject_term)
         self.quantity = convert_quantity(convert_tokens_to_strings(quantity))
@@ -40,12 +36,11 @@ class ExtractedReport:
 
     def display(self):
         print("Location: {}  DateTime: {}  EventTerm: {}  SubjectTerm:  {}  Quantity: {}"
-              .format(self.locations, self.date_times, self.event_term, self.subject_term, self.quantity))
+              .format(self.locations, self.event_term, self.subject_term, self.quantity))
 
     def __eq__(self, other):
-        if isinstance(other, Report):
+        if isinstance(other, ExtractedReport):
             return ((self.locations == other.locations) and
-                    (self.date_times == other.date_times) and
                     (self.event_term == other.event_term) and
                     (self.subject_term == other.subject_term) and
                     (self.quantity == other.quantity)
@@ -58,10 +53,8 @@ class ExtractedReport:
 
     def __repr__(self):
         locations = ",".join(self.locations)
-        dates = ",".join(datetime.strftime(date_time, "%Y-%m-%d")
-                         for date_time in self.date_times)
-        rep = "Locations:{} Dates:{} Verb:{} Noun:{} Quantity:{}".format(
-            locations, dates, self.event_term, self.subject_term, self.quantity)
+        rep = "Locations:{} Verb:{} Noun:{} Quantity:{}".format(
+            locations, self.event_term, self.subject_term, self.quantity)
         return rep
 
     def __hash__(self):
@@ -70,7 +63,6 @@ class ExtractedReport:
     def to_json(self):
         d = {}
         d['Location'] = self.locations
-        d['DateTime'] = self.date_times
         d['EventTerm'] = self.event_term
         d['SubjectTerm'] = self.subject_term
         d['Quantity'] = self.quantity

--- a/notebooks/Pipeline-2.ipynb
+++ b/notebooks/Pipeline-2.ipynb
@@ -1,6 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example notebook for processing URLs and adding results to database\n",
+    "\n",
+    "#### Instructions for use:\n",
+    "\n",
+    "1. To set up DB, set one of `initialize_id_test` or `initialize_id` to True in the cell below\n",
+    "2. If you are not using the docker container, you may need to set up your own PostgreSQL db, and manually change the `user`, `password`, `db_host` and `db` variables\n",
+    "3. If you have not already downloaded the pre-trained model from Dropbox, then set the `model_path` and `encoder_path` to `None` when initializing `Interpreter()` (cell 6)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -12,7 +25,7 @@
     "%autoreload 2\n",
     "# Change these to True to set up the DB the first time\n",
     "i_know_this_will_delete_everything = True\n",
-    "initialize_id_test = True\n",
+    "initialize_id_test = False\n",
     "initialize_id = False\n",
     "\n",
     "import os\n",
@@ -37,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -47,6 +60,7 @@
     "import json\n",
     "from sqlalchemy import create_engine\n",
     "from sqlalchemy import exc\n",
+    "from sqlalchemy import func\n",
     "from datetime import datetime\n",
     "from internal_displacement.model.model import Status, Session, Category, Article, Content, Country, CountryTerm, \\\n",
     "    Location, Report, ReportDateSpan, ArticleCategory, Base\n",
@@ -78,6 +92,7 @@
    },
    "outputs": [],
    "source": [
+    "# Pre-load list of countries into the database\n",
     "load_countries(session)"
    ]
   },
@@ -137,6 +152,7 @@
    },
    "outputs": [],
    "source": [
+    "# Load the pipeline\n",
     "pipeline = Pipeline(session, scraper, interpreter)"
    ]
   },
@@ -148,7 +164,9 @@
    },
    "outputs": [],
    "source": [
-    "test_urls = pd.read_csv('../data_extract/idmc_uniteideas_training_dataset.csv')"
+    "# Load the test urls\n",
+    "test_urls = pd.read_csv('../data/idmc_uniteideas_training_dataset.csv')\n",
+    "test_urls = test_urls['URL'].tolist()"
    ]
   },
   {
@@ -159,18 +177,8 @@
    },
    "outputs": [],
    "source": [
-    "test_urls = test_urls['URL'].tolist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "for url in test_urls[:20]:\n",
+    "# Process the first 40 urls\n",
+    "for url in test_urls[:40]:\n",
     "    try:\n",
     "        pipeline.process_url(url)\n",
     "    except exc.IntegrityError:\n",
@@ -179,35 +187,138 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "40 articles in database\n"
+     ]
     }
    ],
    "source": [
-    "session.query(Article).count()"
+    "print(\"{} articles in database\".format(session.query(Article.id).count()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Article statuses:\n",
+      "fetching failed: 17\n",
+      "new: 1\n",
+      "processed: 22\n"
+     ]
+    }
+   ],
+   "source": [
+    "article_stats = session.query(Article.status, func.count(Article.status)).group_by(Article.status).all()\n",
+    "print(\"Article statuses:\")\n",
+    "for status, ct in article_stats:\n",
+    "    print(\"{}: {}\".format(status, ct))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Look at results for a single URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "url = 'http://floodlist.com/africa/torrential-rains-destroy-400-homes-in-algeria'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "article = session.query(Article).filter_by(url=url).first()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Status: processed\n",
+      "Domain: http://floodlist.com\n",
+      "Language: en\n",
+      "Relevance: True\n",
+      "Category: other\n",
+      "Num Reports: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Status: {}\".format(article.status))\n",
+    "print(\"Domain: {}\".format(article.domain))\n",
+    "print(\"Language: {}\".format(article.language))\n",
+    "print(\"Relevance: {}\".format(article.relevance))\n",
+    "print(\"Category: {}\".format(article.categories[0].category))\n",
+    "print(\"Num Reports: {}\".format(len(article.reports)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "report = article.reports[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event: destroy\n",
+      "Subject: residence\n",
+      "Quantity: 400\n"
+     ]
+    }
+   ],
    "source": [
-    "article = session.query(Article).filter_by(id=19).first()"
+    "print(\"Event: {}\".format(report.event_term))\n",
+    "print(\"Subject: {}\".format(report.subject_term))\n",
+    "print(\"Quantity: {}\".format(report.quantity))"
    ]
   },
   {
@@ -218,18 +329,17 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'http://floodlist.com/africa/torrential-rains-destroy-400-homes-in-algeria'"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Report covers period from 2015-02-01 09:00:00 to 2015-02-01 09:00:00\n"
+     ]
     }
    ],
    "source": [
-    "article.url"
+    "# Datespan\n",
+    "date_span = report.datespans[0]\n",
+    "print(\"Report covers period from {} to {}\".format(date_span.start, date_span.finish))"
    ]
   },
   {
@@ -240,18 +350,17 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'processed'"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 locations found\n"
+     ]
     }
    ],
    "source": [
-    "article.status"
+    "# Location\n",
+    "locations = report.locations\n",
+    "print(\"{} locations found\".format(len(locations)))"
    ]
   },
   {
@@ -262,181 +371,26 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'http://floodlist.com'"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.domain"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2015, 3, 25, 13, 7, 44)"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.publication_date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'en'"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.language"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.relevance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'other'"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.categories[0].category"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('destroy', 'residence', 400)"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.reports[0].event_term, article.reports[0].subject_term, article.reports[0].quantity"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('DZA', 'Tamanrasset')"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "article.reports[0].locations[0].code, article.reports[0].locations[0].description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Algeria\n",
-      "People's Democratic Republic of Algeria\n"
+      "Location: Tamanrasset\n",
+      "City: Tamanrasset\n",
+      "State: None\n",
+      "Country code: DZA\n",
+      "Country name(s): ['Algeria', \"People's Democratic Republic of Algeria\"]\n"
      ]
     }
    ],
    "source": [
-    "for term in article.reports[0].locations[0].country.terms:\n",
-    "    print(term.term)"
+    "location = locations[0]\n",
+    "country = location.country\n",
+    "print(\"Location: {}\".format(location.description))\n",
+    "print(\"City: {}\".format(location.city))\n",
+    "print(\"State: {}\".format(location.subdivision))\n",
+    "print(\"Country code: {}\".format(country.code))\n",
+    "print(\"Country name(s): {}\".format([t.term for t in country.terms]))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR makes a fairly significant change in the way that dates are extracted and processed for reports. 

Rather than trying to associate particular dates with particular events, each report will have a date range associated, that is to say that articles will be said to refer to events that happened in a particular range.

1. Dates are no longer extracted at the same time as other information
2. The new process is as follows:
 - Once an article has been processed, then if it has reports, all possible dates are extracted from the text (using Spacy named entity recognition)
- Each possible date is converted to an absolute datetime
- Certain dates are excluded (i.e. if they are in the future or too far in the past)
- The date-span for each report is then best on the earliest and latest extracted dates
- If no dates are extracted, the publication date is used

There are still a number of opportunities to improve conversion to absolute datetimes.