### PR TITLE
Work with ambiguous relative dates

### DIFF
--- a/internal_displacement/interpreter.py
+++ b/internal_displacement/interpreter.py
@@ -122,8 +122,21 @@ def get_absolute_date(relative_date_string, publication_date=None):
     cal = parsedatetime.Calendar()
     parsed_result = cal.nlp(relative_date_string, publication_date)
     if parsed_result is not None:
-        # Check if parse is successful
-        return parsed_result[0][0]
+        # Parse is successful
+        parsed_absolute_date = parsed_result[0][0]
+
+        # Assumption: input date string is in the past
+        # If parsed date is in the future (relative to publication_date), 
+        #   we roll it back to the past
+        # TODO: need to test if same date works or not
+        #       e.g. publication_date == 18:00 March 31
+        #            relative_date_string == '3 hours ago' OR '15:00'
+        if publication_date and parsed_absolute_date > publication_date:
+            delta = parsed_absolute_date - publication_date
+            return parsed_absolute_date - 2 * delta
+        else:
+            # Return if date is in the past already or no publication_date is provided
+            return parsed_absolute_date
     else:
         return None
 

--- a/internal_displacement/interpreter.py
+++ b/internal_displacement/interpreter.py
@@ -149,7 +149,7 @@ def get_absolute_date(relative_date_string, publication_date=None):
 
                 # If date is specified explicity, and year is not
                 # roll back 1 year
-                return datetime.datetime(parsed_absolute_date.year-1, 
+                return datetime(parsed_absolute_date.year-1, 
                         parsed_absolute_date.month, parsed_absolute_date.day)
             else:
                 # Use the relative datetime delta and roll back

--- a/notebooks/get_abs_date_test.ipynb
+++ b/notebooks/get_abs_date_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -92,14 +92,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Year is not specified"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -112,24 +115,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2015, 12, 28, 0, 0)"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Before publication_date\n",
     "get_absolute_date('28th December', publication_date)"
@@ -137,24 +129,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2016, 10, 26, 0, 0)"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# After publication date\n",
     "get_absolute_date('26th October', publication_date)"
@@ -162,131 +143,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2016, 1, 1, 0, 0)"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_absolute_date('1 January', publication_date)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Relative date string"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2016, 10, 16, 18, 0)"
-      ]
-     },
-     "execution_count": 83,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_absolute_date('2 weeks ago', publication_date)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2016, 10, 30, 15, 30)"
-      ]
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_absolute_date('3:30pm', publication_date)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Year is specified"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2014, 3, 3, 18, 0)"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_absolute_date('March 3 2014', publication_date)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "This is considered **invalid** for now. Since we are assuming articles only contain dates in the past. (for future enhancement)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2017, 3, 3, 0, 0)"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "get_absolute_date('March 3 2018', publication_date)"
    ]
@@ -295,7 +240,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": []

--- a/notebooks/get_abs_date_test.ipynb
+++ b/notebooks/get_abs_date_test.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import parsedatetime\n",
+    "from functools import reduce"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_absolute_date(relative_date_string, publication_date=None):\n",
+    "    \"\"\"\n",
+    "    Turn relative dates into absolute datetimes.\n",
+    "    Currently uses API of parsedatetime\n",
+    "    https://bear.im/code/parsedatetime/docs/index.html\n",
+    "\n",
+    "    Parameters:\n",
+    "    -----------\n",
+    "    relative_date_string        the relative date in an article (e.g. 'Last week'): String\n",
+    "    publication_date            the publication_date of the article: datetime\n",
+    "    \n",
+    "    Returns:\n",
+    "    --------\n",
+    "    One of: \n",
+    "        - a datetime that represents the absolute date of the relative date based on \n",
+    "            the publication_date\n",
+    "        - None, if parse is not successful\n",
+    "    \"\"\"\n",
+    "\n",
+    "    cal = parsedatetime.Calendar()\n",
+    "    parsed_result = cal.nlp(relative_date_string, publication_date)\n",
+    "    if parsed_result is not None:\n",
+    "        # Parse is successful\n",
+    "        parsed_absolute_date = parsed_result[0][0]\n",
+    "\n",
+    "        # Assumption: input date string is in the past\n",
+    "        # If parsed date is in the future (relative to publication_date), \n",
+    "        #   we roll it back to the past\n",
+    "        \n",
+    "        if publication_date and parsed_absolute_date > publication_date:\n",
+    "            # parsedatetime returns a date in the future\n",
+    "            # likely because year isn't specified or date_string is relative\n",
+    "            \n",
+    "            # Check a specific date is included\n",
+    "            # TODO: Smarter way or regex to check if relative_date_string \n",
+    "            #       contains a month name?\n",
+    "            months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', \n",
+    "                      'jul', 'aug', 'sep', 'oct', 'nov', 'dec']\n",
+    "            contains_month = reduce( \n",
+    "                    lambda result, month: result or relative_date_string.lower().find(month) != -1, \n",
+    "                    months, False)\n",
+    "            \n",
+    "            if contains_month:\n",
+    "                # TODO: Is it enough to just check for month names to determine if a \n",
+    "                #       date_string specifies a particular date?\n",
+    "\n",
+    "                # If date is specified explicity, and year is not\n",
+    "                # roll back 1 year\n",
+    "                return datetime.datetime(parsed_absolute_date.year-1, \n",
+    "                        parsed_absolute_date.month, parsed_absolute_date.day)\n",
+    "            else:\n",
+    "                # Use the relative datetime delta and roll back\n",
+    "                delta = parsed_absolute_date - publication_date\n",
+    "                num_weeks = int(delta.days/7)\n",
+    "                and_num_days_after = 7 if delta.days%7 == 0 else delta.days%7\n",
+    "                return publication_date - datetime.timedelta(weeks=num_weeks) - \\\n",
+    "                        datetime.timedelta(7-and_num_days_after)\n",
+    "        else:\n",
+    "            # Return if date is in the past already or no publication_date is provided\n",
+    "            return parsed_absolute_date\n",
+    "    else:\n",
+    "        # Parse unsucessful\n",
+    "        return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Year is not specified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    " publication_date = datetime.datetime(2016, 10, 30, 18, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2015, 12, 28, 0, 0)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Before publication_date\n",
+    "get_absolute_date('28th December', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2016, 10, 26, 0, 0)"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# After publication date\n",
+    "get_absolute_date('26th October', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2016, 1, 1, 0, 0)"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_absolute_date('1 January', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Relative date string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2016, 10, 16, 18, 0)"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_absolute_date('2 weeks ago', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2016, 10, 30, 15, 30)"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_absolute_date('3:30pm', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Year is specified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2014, 3, 3, 18, 0)"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_absolute_date('March 3 2014', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is considered **invalid** for now. Since we are assuming articles only contain dates in the past. (for future enhancement)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 3, 3, 0, 0)"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_absolute_date('March 3 2018', publication_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Assuming all dates in articles are *before* the publication date (if available). 
So this change only affects date strings to be parsed with a publication date passed along. 